### PR TITLE
add tensorboardX to requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ torchcrepe==0.0.20
 tqdm==4.65.0
 yt_dlp==2023.7.6
 sox==1.4.1
+tensorboardX==2.6.2.2


### PR DESCRIPTION
fairseq framework outputs info-level log complaining about missing tensorboardX. This PR fixes that by adding tensorboardX to requirements file 