### PR TITLE
Overhaul intermediate file caching system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # MDX Models
+
+song_output
 mdxnet_models/*.onnx
 
 # RVC Models

--- a/song_output/OUTPUT.txt
+++ b/song_output/OUTPUT.txt
@@ -1,1 +1,0 @@
-Output is stored in this folder, where directory names represent the YouTube IDs from the original song.

--- a/src/mdx.py
+++ b/src/mdx.py
@@ -341,9 +341,11 @@ def run_mdx(
     stem_name = model.stem_name if suffix is None else suffix
 
     main_filepath = None
-    base_name = os.path.basename(os.path.splitext(filename)[0]).removesuffix(f"_{sr}")
+    base_name = os.path.basename(os.path.splitext(filename)[0]).removesuffix(
+        f"_sr_{sr}"
+    )
     if not exclude_main:
-        main_filepath = os.path.join(output_dir, f"{base_name}_{stem_name}_{sr}.wav")
+        main_filepath = os.path.join(output_dir, f"{base_name}_{stem_name}_sr_{sr}.wav")
         sf.write(main_filepath, wave_processed.T, sr)
 
     invert_filepath = None
@@ -352,7 +354,9 @@ def run_mdx(
             stem_naming.get(stem_name) if invert_suffix is None else invert_suffix
         )
         stem_name = f"{stem_name}_diff" if diff_stem_name is None else diff_stem_name
-        invert_filepath = os.path.join(output_dir, f"{base_name}_{stem_name}_{sr}.wav")
+        invert_filepath = os.path.join(
+            output_dir, f"{base_name}_{stem_name}_sr_{sr}.wav"
+        )
         sf.write(invert_filepath, (-wave_processed.T * model.compensation) + wave.T, sr)
 
     if not keep_orig:

--- a/src/webui.py
+++ b/src/webui.py
@@ -339,6 +339,7 @@ with gr.Blocks(title="AICoverGenWebUI") as app:
                     )
             keep_files = gr.Checkbox(
                 label="Keep intermediate files",
+                value=True,
                 info="Keep all audio files generated in the song_output/id directory, e.g. Isolated Vocals/Instrumentals. Leave unchecked to save space",
             )
 


### PR DESCRIPTION
Overhaul intermediate file caching system so that as many audio files as possible are saved and not re-recomputed unless strictly necessary. Also changes the behaviour of the `keep_files` parameter so that all intermediate files are deleted after generation of the final audio file when it is checked. Finally, this PR sets the default value of `keep_files` to be false.