### PR TITLE
fix long file names

### DIFF
--- a/src/mdx.py
+++ b/src/mdx.py
@@ -347,11 +347,8 @@ def run_mdx(
     stem_name = model.stem_name if suffix is None else suffix
 
     main_filepath = None
-    base_name = os.path.basename(os.path.splitext(filename)[0]).removesuffix(
-        f"_sr_{sr}"
-    )
     if not exclude_main:
-        main_filepath = os.path.join(output_dir, f"{base_name}_{stem_name}_sr_{sr}.wav")
+        main_filepath = os.path.join(output_dir, f"{stem_name}.wav")
         sf.write(main_filepath, wave_processed.T, sr)
 
     invert_filepath = None
@@ -360,9 +357,7 @@ def run_mdx(
             stem_naming.get(stem_name) if invert_suffix is None else invert_suffix
         )
         stem_name = f"{stem_name}_diff" if diff_stem_name is None else diff_stem_name
-        invert_filepath = os.path.join(
-            output_dir, f"{base_name}_{stem_name}_sr_{sr}.wav"
-        )
+        invert_filepath = os.path.join(output_dir, f"{stem_name}.wav")
         sf.write(invert_filepath, (-wave_processed.T * model.compensation) + wave.T, sr)
 
     if not keep_orig:

--- a/src/webui.py
+++ b/src/webui.py
@@ -650,19 +650,19 @@ with gr.Blocks(title="AICoverGenWebUI") as app:
             outputs=[song_dir, input_type],
         ).success(
             partial(duplication_harness, retrieve_song),
-            inputs=[song_input, input_type, song_dir, output_sr],
+            inputs=[song_input, input_type, song_dir],
             outputs=[ai_cover, original_track],
         ).success(
             partial(duplication_harness, separate_vocals),
-            inputs=[song_dir, output_sr],
+            inputs=[original_track, song_dir, output_sr],
             outputs=[ai_cover, vocals_track, instrumentals_track],
         ).success(
             partial(duplication_harness, separate_main_vocals),
-            inputs=[song_dir, output_sr],
+            inputs=[vocals_track, song_dir, output_sr],
             outputs=[ai_cover, background_vocals_track, main_vocals_track],
         ).success(
             partial(duplication_harness, dereverb_main_vocals),
-            inputs=[song_dir, output_sr],
+            inputs=[main_vocals_track, song_dir, output_sr],
             outputs=[ai_cover, main_vocals_dereverbed_track],
         ).success(
             partial(duplication_harness, convert_main_vocals),
@@ -716,7 +716,6 @@ with gr.Blocks(title="AICoverGenWebUI") as app:
                 mixed_ai_vocals_track,
                 rvc_model,
                 song_dir,
-                pitch_all,
                 main_gain,
                 backup_gain,
                 inst_gain,


### PR DESCRIPTION
Refactor code so that intermediate audio files are distinguished by a hash based on the parameters they were generated using, rather than have these parameters in the file name of the audio files.