### PR TITLE
Add-launcher-scripts-for-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ultimate RVC
+
 An autonomous pipeline to create covers with any RVC v2 trained AI voice from YouTube videos or a local audio file. For developers who may want to add a singing functionality into their AI assistant/chatbot/vtuber, or for people who want to hear their favourite characters sing their favourite song.
 
 Showcase: TBA
@@ -14,6 +15,7 @@ Ultimate RVC is under constant development and testing, but you can try it out r
 TBA
 
 ### PRO TIP: Use a GPU for faster processing
+
 While it is possible to run the Ultimate RVC web app on a CPU, it is highly recommended to use a GPU for faster processing. On an NVIDIA 3080 GPU, the AI cover generation process takes approximately 1.5 minutes, while on a CPU, it takes approximately 15 minutes. No testing has been done on AMD GPUs, so no guarantees are made for their performance.
 
 ## Setup
@@ -21,7 +23,6 @@ While it is possible to run the Ultimate RVC web app on a CPU, it is highly reco
 ### Install Git
 
 Follow the instructions [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) to install Git on your computer.
-
 
 ### Clone Ultimate RVC repository
 Open a terminal and run the following commands to clone this entire repository and open it locally.
@@ -34,15 +35,20 @@ cd ultimate-rvc
 
 #### Windows
 Run the following command to install the necessary dependencies on Windows:
-
 ```
 ./urvc.bat install 
 ```
-Note that this will install Visual Studio build tools in your Program Files directory and will install Miniconda in your user directory. The whole process may take upwards of 15 minutes, so grab a cup of coffee and wait.
+Note that this will install Visual Studio build tools in your Program Files directory and will install Miniconda in your user directory. 
+The whole process may take upwards of 15 minutes, so grab a cup of coffee and wait.
 
-#### Unix
+#### Linux (Debian-based)
 
-TBA
+Run the following command to install the necessary dependencies on Debian-based Linux distributions (e.g. Ubuntu):
+```
+./urvc.sh install 
+```
+The command has been tested only on Ubuntu 22.04 and 24.04 so support for other distributions is not guaranteed. 
+Also note that the command will install the CUDA 11.8 toolkit system-wide. In case you have problems, you may need to install the toolkit manually.
 
 ## Usage
 
@@ -50,15 +56,15 @@ TBA
 
 #### Windows
 
-To start the Ultimate RVC web app in your browser on Windows, run the following command:
-
 ```
 ./urvc.bat run
 ```
 
-#### Unix
-TBA 
+#### Linux (Debian-based)
 
+```
+./urvc.sh run
+```
 
 Once the following output message `Running on local URL:  http://127.0.0.1:7860` appears, you can click on the link to open a tab with the web app.
 
@@ -107,14 +113,38 @@ TBA
 ## CLI
 TBA
 
-# Update to latest version
-## Windows
-Run the following command to pull latest changes from the repository and reinstall dependencies on Windows:
+## Update to latest version
+
+Run the following command to pull latest changes from the repository and reinstall dependencies. 
+Note that the process may take upwards of 10 minutes.
+#### Windows
 
 ```
 ./urvc.bat update
 ```
-Note that the process may take upwards of 10 minutes.
+
+#### Linux (Debian-based)
+
+```
+./urvc.sh update
+```
+
+## Development mode
+
+When developing new features or debugging, it is recommended to run the app in development mode. This enables hot reloading, which means that the app will automatically reload when changes are made to the code.
+
+#### Windows
+
+```
+./urvc.bat dev
+```
+
+#### Linux (Debian-based)
+
+```
+./urvc.sh dev
+```
+
 
 ## Terms of Use
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ sox==1.4.1
 #deemix
 
 # Machine learning
+git+https://github.com/JackismyShephard/fairseq; sys_platform == 'linux'
 fairseq==0.12.2; sys_platform == 'darwin' or sys_platform == 'win32'
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.1.1+cu118 # NOTE upgraded from 2.0.1+cu118

--- a/urvc.sh
+++ b/urvc.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Launcher script for Ultimate RVC on Debian-based linux systems.
+# Currently only supports Ubuntu 22.04 and Ubuntu 24.04.
+
+main() {
+    case $1 in
+        install)
+            echo "Installing Ultimate RVC"
+            sudo apt install -y build-essential software-properties-common
+            install_distro_specifics
+            install_cuda_118
+            sudo add-apt-repository -y ppa:deadsnakes/ppa
+            sudo apt install -y python3.10 python3.10-dev python3.10-venv
+            sudo apt install -y sox libsox-dev ffmpeg
+
+            python3.10 -m venv .venv --upgrade-deps 
+            . .venv/bin/activate
+            pip cache purge
+            pip install -r requirements.txt
+            pip install faiss-cpu==1.7.3
+            pip uninstall torch torchaudio -y
+            pip install torch==2.1.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu118
+            python ./src/init.py
+            deactivate
+            echo
+            echo "Ultimate RVC has been installed successfully"
+            exit 0
+            ;;
+        run)
+            echo "Starting Ultimate RVC"
+            ./.venv/bin/python ./src/app.py
+            exit 0
+            ;;
+        update)
+            echo "Updating Ultimate RVC"
+            git pull
+            rm -rf .venv
+            python3.10 -m venv .venv --upgrade-deps
+            . .venv/bin/activate
+            pip cache purge
+            pip install -r requirements.txt
+            pip install faiss-cpu==1.7.3
+            pip uninstall torch torchaudio -y
+            pip install torch==2.1.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu118
+            deactivate
+            echo
+            echo "Ultimate RVC has been updated successfully"
+            exit 0
+            ;;
+        dev)
+            echo "Starting Ultimate RVC in development mode"
+            ./.venv/bin/gradio ./src/app.py --demo-name app
+            exit 0
+            ;;
+        *)
+            echo "Usage ./urvc.sh [install|run|update|dev]"
+            exit 1
+            ;;
+    esac
+}
+
+install_distro_specifics() {
+    . /etc/lsb-release
+    case $DISTRIB_ID in
+        Ubuntu)
+            case $DISTRIB_RELEASE in
+                24.04)
+                    # Add Ubuntu 23.10 repository to sources.list so that we can install cuda 11.8 toolkit
+
+                    # sed command removes leading whitespace from subsequent lines
+                    TEXT=$(sed 's/^[[:space:]]*//' <<< "\
+                    ##
+                    ## Added by Ultimate RVC installer
+                    Types: deb
+                    URIs: http://archive.ubuntu.com/ubuntu/
+                    Suites: lunar
+                    Components: universe
+                    Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg"
+                    )
+                    FILE=/etc/apt/sources.list.d/ubuntu.sources
+                    # Append to file if not already present
+                    grep -qxF "## Added by Ultimate RVC installer" "$FILE" || echo "$TEXT" | sudo tee -a "$FILE"
+                    sudo apt update
+                    ;;
+                22.04)
+                    sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg6
+                    ;;
+                *)
+                    echo "Unsupported Ubuntu version"
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported debian distribution"
+            exit 1
+            ;;
+    esac
+}
+
+install_cuda_118() {
+    echo "Installing CUDA 11.8"
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+    sudo dpkg -i cuda-keyring_1.0-1_all.deb
+    sudo apt-get update
+    sudo apt-get -y install cuda-toolkit-11-8
+    rm -rf cuda-keyring_1.0-1_all.deb
+    echo "CUDA 11.8 has been installed successfully"
+}
+
+main $@


### PR DESCRIPTION
Adds a launcher script for installing, updating and running Ultimate RVC on debian-based linux systems (E.g. Ubuntu). Also updates the README with new instructions. 