### PR TITLE
type unions using | syntax

### DIFF
--- a/src/backend/common.py
+++ b/src/backend/common.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any
 from extra_typing import StrOrBytesPath
 import gradio as gr
 import os
@@ -14,8 +14,8 @@ TEMP_AUDIO_DIR = os.path.join(SONGS_DIR, "temp")
 
 def display_progress(
     message: str,
-    percentage: Optional[float] = None,
-    progress_bar: Optional[gr.Progress] = None,
+    percentage: float | None = None,
+    progress_bar: gr.Progress | None = None,
 ) -> None:
     if progress_bar is None:
         print(message)

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Any
+from typing import Any
 from extra_typing import InputType, F0Method, InputAudioExt, OutputAudioExt
 import gradio as gr
 
@@ -42,7 +42,7 @@ from backend.mdx import run_mdx
 from vc.rvc import Config, load_hubert, get_vc, rvc_infer
 
 
-def _get_youtube_video_id(url: str, ignore_playlist: bool = True) -> Optional[str]:
+def _get_youtube_video_id(url: str, ignore_playlist: bool = True) -> str | None:
     """
     Examples:
     http://youtu.be/SA2iWivDJiE
@@ -103,7 +103,7 @@ def _get_cached_input_paths() -> list[str]:
     return glob.glob(os.path.join(TEMP_AUDIO_DIR, "*", "0_*_Original*"))
 
 
-def _get_orig_song_path(song_dir: str) -> Optional[str]:
+def _get_orig_song_path(song_dir: str) -> str | None:
     # NOTE orig_song_paths should never contain more than one element
     return next(iter(glob.glob(os.path.join(song_dir, "0_*_Original*"))), None)
 
@@ -123,7 +123,7 @@ def _get_unique_base_path(
     song_dir: str,
     prefix: str,
     arg_dict: dict[str, Any],
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
     hash_size: int = 5,
 ) -> str:
@@ -265,7 +265,7 @@ def get_named_song_dirs() -> list[tuple[str, str]]:
 
 def delete_intermediate_audio(
     song_inputs: list[str],
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
     if not song_inputs:
@@ -290,7 +290,7 @@ def delete_intermediate_audio(
 
 
 def delete_all_intermediate_audio(
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [0.0],
 ) -> str:
     if len(percentages) != 1:
@@ -307,7 +307,7 @@ def delete_all_intermediate_audio(
 def convert_to_stereo(
     song_path: str,
     song_dir: str,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
     if not song_path:
@@ -350,7 +350,7 @@ def convert_to_stereo(
 
 def _make_song_dir(
     song_input: str,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> tuple[str, InputType]:
     # if song directory
@@ -392,7 +392,7 @@ def _make_song_dir(
 
 def retrieve_song(
     song_input: str,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [i / 3 for i in range(3)],
 ) -> tuple[str, str]:
     if len(percentages) != 3:
@@ -432,7 +432,7 @@ def separate_vocals(
     song_path: str,
     song_dir: str,
     stereofy: bool = True,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [i / 2 for i in range(2)],
 ) -> tuple[str, str]:
     if len(percentages) != 2:
@@ -500,7 +500,7 @@ def separate_main_vocals(
     vocals_path: str,
     song_dir: str,
     stereofy: bool = True,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [i / 2 for i in range(2)],
 ) -> tuple[str, str]:
     if len(percentages) != 2:
@@ -572,7 +572,7 @@ def dereverb_vocals(
     vocals_path: str,
     song_dir: str,
     stereofy: bool = True,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [i / 2 for i in range(2)],
 ) -> tuple[str, str]:
     if len(percentages) != 2:
@@ -652,7 +652,7 @@ def convert_vocals(
     protect: float = 0.33,
     f0_method: F0Method = "rmvpe",
     crepe_hop_length: int = 128,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
     if not vocals_path:
@@ -721,7 +721,7 @@ def postprocess_vocals(
     reverb_wet: float = 0.2,
     reverb_dry: float = 0.8,
     reverb_damping: float = 0.7,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
 
@@ -779,7 +779,7 @@ def pitch_shift_background(
     backup_vocals_path: str,
     song_dir: str,
     pitch_change: int = 0,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [i / 2 for i in range(2)],
 ) -> tuple[str, str]:
     if len(percentages) != 2:
@@ -876,7 +876,7 @@ def pitch_shift_background(
 
 
 def _get_voice_model(
-    mixed_vocals_path: Optional[str] = None, song_dir: Optional[str] = None
+    mixed_vocals_path: str | None = None, song_dir: str | None = None
 ) -> str:
     voice_model = "Unknown"
     if not (mixed_vocals_path and song_dir):
@@ -899,10 +899,10 @@ def _get_voice_model(
 
 
 def get_song_cover_name(
-    mixed_vocals_path: Optional[str] = None,
-    song_dir: Optional[str] = None,
-    voice_model: Optional[str] = None,
-    progress_bar: Optional[gr.Progress] = None,
+    mixed_vocals_path: str | None = None,
+    song_dir: str | None = None,
+    voice_model: str | None = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
     display_progress("[~] Getting song cover name...", percentage, progress_bar)
@@ -929,9 +929,9 @@ def mix_song_cover(
     backup_gain: int = 0,
     output_sr: int = 44100,
     output_format: InputAudioExt = "mp3",
-    output_name: Optional[str] = None,
+    output_name: str | None = None,
     keep_files: bool = True,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [i / 3 for i in range(3)],
 ) -> str:
     if len(percentages) != 3:
@@ -1038,11 +1038,11 @@ def run_pipeline(
     backup_gain: int = 0,
     output_sr: int = 44100,
     output_format: InputAudioExt = "mp3",
-    output_name: Optional[str] = None,
+    output_name: str | None = None,
     keep_files: bool = True,
     return_files: bool = False,
-    progress_bar: Optional[gr.Progress] = None,
-) -> Union[str, tuple[str, ...]]:
+    progress_bar: gr.Progress | None = None,
+) -> str | tuple[str, ...]:
     display_progress("[~] Starting song cover generation pipeline...", 0, progress_bar)
     percentages = [i / 16 for i in range(16)]
     orig_song_path, song_dir = retrieve_song(song_input, progress_bar, percentages[:3])

--- a/src/backend/manage_voice_models.py
+++ b/src/backend/manage_voice_models.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from extra_typing import ModelsTable, ModelsTablePredicate
 import os
 import shutil
@@ -26,7 +25,7 @@ def get_current_models() -> list[str]:
 
 def load_public_models_table(
     predicates: list[ModelsTablePredicate],
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> ModelsTable:
     models_table: ModelsTable = []
@@ -46,7 +45,7 @@ def load_public_model_tags() -> list[str]:
 def filter_public_models_table(
     tags: list[str],
     query: str,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> ModelsTable:
 
@@ -131,7 +130,7 @@ def _extract_model_zip(extraction_folder: str, zip_name: str, remove_zip: bool) 
 def download_online_model(
     url: str,
     dir_name: str,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentages: list[float] = [0.0, 0.5],
 ) -> str:
     if len(percentages) != 2:
@@ -167,7 +166,7 @@ def download_online_model(
 def upload_local_model(
     input_paths: list[str],
     dir_name: str,
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
     if not input_paths:
@@ -216,7 +215,7 @@ def upload_local_model(
 
 def delete_models(
     model_names: list[str],
-    progress_bar: Optional[gr.Progress] = None,
+    progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
     if not model_names:
@@ -239,7 +238,7 @@ def delete_models(
 
 
 def delete_all_models(
-    progress_bar: Optional[gr.Progress] = None, percentage: float = 0.0
+    progress_bar: gr.Progress | None = None, percentage: float = 0.0
 ) -> str:
     all_models = get_current_models()
     display_progress("[~] Deleting all models ...", percentage, progress_bar)

--- a/src/extra_typing.py
+++ b/src/extra_typing.py
@@ -1,21 +1,17 @@
-from typing import TypeVar, Optional, Union, Callable, Any, Literal
+from typing import TypeVar, Callable, Any, Literal
 from os import PathLike
 from typing_extensions import ParamSpec, TypedDict
 
 P = ParamSpec("P")
 T = TypeVar("T")
 
-StrOrBytesPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+StrOrBytesPath = str | bytes | PathLike[str] | PathLike[bytes]
 
-InputChoices = Union[list[tuple[str, str]], list[str]]
+InputChoices = list[tuple[str, str]] | list[str]
 
-DropdownChoices = Optional[
-    list[Union[str, int, float, tuple[str, Union[str, int, float]]]]
-]
+DropdownChoices = list[str | int | float | tuple[str, str | int | float]] | None
 
-DropdownValue = Union[
-    str, int, float, list[Union[str, int, float]], Callable[..., Any], None
-]
+DropdownValue = str | int | float | list[str | int | float] | Callable[..., Any] | None
 
 InputType = Literal["yt", "local"]
 
@@ -59,17 +55,17 @@ class ComponentInteractivityUpdate(TypedDict):
 
 
 class UpdateDropdownArgs(TypedDict, total=False):
-    choices: Optional[DropdownChoices]
-    value: Optional[DropdownValue]
+    choices: DropdownChoices | None
+    value: DropdownValue | None
 
 
 class TextBoxArgs(TypedDict, total=False):
-    value: Optional[str]
-    placeholder: Optional[str]
+    value: str | None
+    placeholder: str | None
 
 
 class TransferUpdateArgs(TypedDict, total=False):
-    value: Optional[str]
+    value: str | None
 
 
 MixSongCoverHarnessArgs = tuple[str, int, int, int, int, InputAudioExt, str, bool]

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -1,9 +1,7 @@
 from typing import (
     Callable,
     Literal,
-    Optional,
     Any,
-    Union,
     Sequence,
 )
 from typing_extensions import Concatenate
@@ -128,9 +126,9 @@ def show_hop_slider(
 
 
 def get_song_cover_name_harness(
-    mixed_vocals: Optional[str] = None,
-    song_dir: Optional[str] = None,
-    voice_model: Optional[str] = None,
+    mixed_vocals: str | None = None,
+    song_dir: str | None = None,
+    voice_model: str | None = None,
     update_key: SongCoverNameUpdateKey = "value",
 ) -> gr.Textbox:
     update_args: TextBoxArgs = {}
@@ -147,15 +145,15 @@ def get_song_cover_name_harness(
 @dataclass
 class EventArgs:
     fn: Callable[..., Any]
-    inputs: Optional[Sequence[Component]] = None
-    outputs: Optional[Sequence[Component]] = None
+    inputs: Sequence[Component] | None = None
+    outputs: Sequence[Component] | None = None
     name: Literal["click", "success", "then"] = "success"
     show_progress: Literal["full", "minimal", "hidden"] = "full"
 
 
 def setup_consecutive_event_listeners(
     component: Component, event_args_list: list[EventArgs]
-) -> Union[Dependency, Component]:
+) -> Dependency | Component:
     if len(event_args_list) == 0:
         raise ValueError("Event args list must not be empty.")
     dependency = component
@@ -174,7 +172,7 @@ def setup_consecutive_event_listeners_with_toggled_interactivity(
     component: Component,
     event_args_list: list[EventArgs],
     toggled_components: Sequence[Component],
-) -> Union[Dependency, Component]:
+) -> Dependency | Component:
     if len(event_args_list) == 0:
         raise ValueError("Event args list must not be empty.")
 

--- a/src/frontend/tabs/one_click_generation.py
+++ b/src/frontend/tabs/one_click_generation.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union, Optional
+from typing import Callable
 from typing_extensions import Unpack
 from extra_typing import P, MixSongCoverHarnessArgs, RunPipelineHarnessArgs
 from functools import partial
@@ -36,7 +36,7 @@ from backend.generate_song_cover import (
 
 
 def _duplication_harness(
-    fun: Callable[P, Union[str, tuple[str, ...]]],
+    fun: Callable[P, str | tuple[str, ...]],
 ) -> Callable[P, tuple[str, ...]]:
     def _wrapped(*args: P.args, **kwargs: P.kwargs) -> tuple[str, ...]:
 
@@ -70,7 +70,7 @@ def _mix_song_cover_harness(
 
 def _run_pipeline_harness(
     *args: Unpack[RunPipelineHarnessArgs],
-) -> tuple[Optional[str], ...]:
+) -> tuple[str | None, ...]:
 
     res = exception_harness(run_pipeline)(*args, progress_bar=PROGRESS_BAR)
     if isinstance(res, tuple):
@@ -81,7 +81,7 @@ def _run_pipeline_harness(
 
 def _toggle_intermediate_files_accordion(
     visible: bool,
-) -> list[Union[gr.Accordion, gr.Audio]]:
+) -> list[gr.Accordion | gr.Audio]:
     audio_components = list(gr.Audio(value=None) for _ in range(11))
     accordions = list(gr.Accordion(open=False) for _ in range(7))
     return [gr.Accordion(visible=visible, open=False)] + accordions + audio_components

--- a/urvc.bat
+++ b/urvc.bat
@@ -6,7 +6,7 @@ set "ROOT=%cd%"
 set "URL_MAIN=https://huggingface.co/JackismyShephard/ultimate-rvc/resolve/main"
 
 set "DEPENDENCIES_DIR=%ROOT%\dependencies"
-set "VIRTUAL_ENV_DIR=%DEPENDENCIES_DIR%\venv"
+set "VIRTUAL_ENV_DIR=%DEPENDENCIES_DIR%\.venv"
 set "CONDA_ROOT=%UserProfile%\Miniconda3"
 set "CONDA_EXE_DIR=%CONDA_ROOT%\Scripts"
 


### PR DESCRIPTION
Now that app is running on python3.10 we can finally replace `Union` and `Optional` types with the `|` typing operator. 

Additionally, this PR also updates the launcher script for windows so that the conda virtual environment is installed in `dependencies/.venv` rather than `dependencies/venv`