### PR TITLE
Move-delete-audio-functionality-to-dedicated-tab

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from backend.manage_voice_models import get_current_models
 from frontend.tabs.one_click_generation import render as render_one_click_tab
 from frontend.tabs.multi_step_generation import render as render_multi_step_tab
 from frontend.tabs.manage_models import render as render_manage_models_tab
+from frontend.tabs.manage_audio import render as render_manage_audio_tab
 
 
 def _refresh_dropdowns() -> tuple[gr.Dropdown, ...]:
@@ -91,8 +92,6 @@ with gr.Blocks(title="Ultimate RVC") as app:
     # main tab
     with gr.Tab("Generate song covers"):
         render_one_click_tab(
-            dummy_deletion_checkbox,
-            delete_confirmation,
             generate_buttons,
             song_dir_dropdowns,
             cached_input_songs_dropdown,
@@ -115,6 +114,16 @@ with gr.Blocks(title="Ultimate RVC") as app:
             rvc_models_to_delete,
             rvc_model,
             rvc_model2,
+        )
+    with gr.Tab("Manage audio"):
+
+        render_manage_audio_tab(
+            dummy_deletion_checkbox,
+            delete_confirmation,
+            song_dir_dropdowns,
+            cached_input_songs_dropdown,
+            cached_input_songs_dropdown2,
+            intermediate_audio_to_delete,
         )
 
     app.load(

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -889,12 +889,11 @@ def mix_song_cover(
     output_sr: int = 44100,
     output_format: InputAudioExt = "mp3",
     output_name: str | None = None,
-    keep_files: bool = True,
     progress_bar: gr.Progress | None = None,
-    percentages: list[float] = [i / 3 for i in range(3)],
+    percentages: list[float] = [i / 2 for i in range(2)],
 ) -> str:
-    if len(percentages) != 3:
-        raise ValueError("Percentages must be a list of length 3.")
+    if len(percentages) != 2:
+        raise ValueError("Percentages must be a list of length 2.")
     if not main_vocals_path:
         raise InputMissingError("Main vocals missing!")
     if not os.path.isfile(main_vocals_path):
@@ -967,13 +966,6 @@ def mix_song_cover(
     song_cover_path = os.path.join(SONGS_DIR, f"{output_name}.{output_format}")
     shutil.copyfile(mixdown_path, song_cover_path)
 
-    if not keep_files:
-        display_progress(
-            f"[~] Removing intermediate audio files in directory for song...",
-            percentages[2],
-            progress_bar,
-        )
-        shutil.rmtree(song_dir)
     return song_cover_path
 
 
@@ -998,12 +990,11 @@ def run_pipeline(
     output_sr: int = 44100,
     output_format: InputAudioExt = "mp3",
     output_name: str | None = None,
-    keep_files: bool = True,
     return_files: bool = False,
     progress_bar: gr.Progress | None = None,
 ) -> str | tuple[str, ...]:
     display_progress("[~] Starting song cover generation pipeline...", 0, progress_bar)
-    percentages = [i / 16 for i in range(16)]
+    percentages = [i / 15 for i in range(15)]
     orig_song_path, song_dir = retrieve_song(song_input, progress_bar, percentages[:3])
     vocals_path, instrumentals_path = separate_vocals(
         orig_song_path, song_dir, False, progress_bar, percentages[3:5]
@@ -1059,11 +1050,10 @@ def run_pipeline(
         output_sr,
         output_format,
         output_name,
-        keep_files,
         progress_bar,
-        percentages[13:16],
+        percentages[13:15],
     )
-    if keep_files and return_files:
+    if return_files:
         return (
             orig_song_path,
             vocals_path,

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -263,47 +263,6 @@ def get_named_song_dirs() -> list[tuple[str, str]]:
     return sorted(named_song_dirs, key=lambda x: x[0])
 
 
-def delete_intermediate_audio(
-    song_inputs: list[str],
-    progress_bar: gr.Progress | None = None,
-    percentage: float = 0.0,
-) -> str:
-    if not song_inputs:
-        raise InputMissingError(
-            "Song inputs missing! Please provide a non-empty list of song directories"
-        )
-    display_progress(
-        "[~] Deleting intermediate audio files for selected songs...",
-        percentage,
-        progress_bar,
-    )
-    for song_input in song_inputs:
-        if not os.path.isdir(song_input):
-            raise PathNotFoundError(f"Song directory '{song_input}' does not exist.")
-
-        if not PurePath(song_input).parent == PurePath(TEMP_AUDIO_DIR):
-            raise InvalidPathError(
-                f"Song directory '{song_input}' is not located in the intermediate audio root directory."
-            )
-        shutil.rmtree(song_input)
-    return "[+] Successfully deleted intermediate audio files for selected songs!"
-
-
-def delete_all_intermediate_audio(
-    progress_bar: gr.Progress | None = None,
-    percentages: list[float] = [0.0],
-) -> str:
-    if len(percentages) != 1:
-        raise ValueError("Percentages must be a list of length 1.")
-    display_progress(
-        "[~] Deleting all intermediate audio files...", percentages[0], progress_bar
-    )
-    if os.path.isdir(TEMP_AUDIO_DIR):
-        shutil.rmtree(TEMP_AUDIO_DIR)
-
-    return "[+] All intermediate audio files successfully deleted!"
-
-
 def convert_to_stereo(
     song_path: str,
     song_dir: str,

--- a/src/backend/manage_audio.py
+++ b/src/backend/manage_audio.py
@@ -1,0 +1,47 @@
+import os
+from pathlib import PurePath
+import shutil
+
+import gradio as gr
+
+from backend.exceptions import InputMissingError, InvalidPathError, PathNotFoundError
+from backend.common import display_progress, TEMP_AUDIO_DIR
+
+
+def delete_intermediate_audio(
+    song_inputs: list[str],
+    progress_bar: gr.Progress | None = None,
+    percentage: float = 0.0,
+) -> str:
+    if not song_inputs:
+        raise InputMissingError(
+            "Song inputs missing! Please provide a non-empty list of song directories"
+        )
+    display_progress(
+        "[~] Deleting intermediate audio files for selected songs...",
+        percentage,
+        progress_bar,
+    )
+    for song_input in song_inputs:
+        if not os.path.isdir(song_input):
+            raise PathNotFoundError(f"Song directory '{song_input}' does not exist.")
+
+        if not PurePath(song_input).parent == PurePath(TEMP_AUDIO_DIR):
+            raise InvalidPathError(
+                f"Song directory '{song_input}' is not located in the intermediate audio root directory."
+            )
+        shutil.rmtree(song_input)
+    return "[+] Successfully deleted intermediate audio files for selected songs!"
+
+
+def delete_all_intermediate_audio(
+    progress_bar: gr.Progress | None = None,
+    percentages: list[float] = [0.0],
+) -> str:
+    if len(percentages) != 1:
+        raise ValueError("Percentages must be a list of length 1.")
+    display_progress("[~] Deleting all audio files...", percentages[0], progress_bar)
+    if os.path.isdir(TEMP_AUDIO_DIR):
+        shutil.rmtree(TEMP_AUDIO_DIR)
+
+    return "[+] All intermediate audio files successfully deleted!"

--- a/src/cli.py
+++ b/src/cli.py
@@ -171,7 +171,6 @@ if __name__ == "__main__":
         inst_gain=args.inst_vol,
         output_sr=args.output_sr,
         output_format=args.output_format,
-        keep_files=args.keep_files,
         return_files=False,
         progress_bar=None,
     )

--- a/src/extra_typing.py
+++ b/src/extra_typing.py
@@ -68,7 +68,7 @@ class TransferUpdateArgs(TypedDict, total=False):
     value: str | None
 
 
-MixSongCoverHarnessArgs = tuple[str, int, int, int, int, InputAudioExt, str, bool]
+MixSongCoverHarnessArgs = tuple[str, int, int, int, int, InputAudioExt, str]
 
 RunPipelineHarnessArgs = tuple[
     str,
@@ -91,6 +91,5 @@ RunPipelineHarnessArgs = tuple[
     int,
     InputAudioExt,
     str,
-    bool,
     bool,
 ]

--- a/src/frontend/tabs/manage_audio.py
+++ b/src/frontend/tabs/manage_audio.py
@@ -1,0 +1,92 @@
+from functools import partial
+import gradio as gr
+
+from backend.manage_audio import (
+    delete_all_intermediate_audio,
+    delete_intermediate_audio,
+)
+from frontend.common import (
+    identity,
+    confirm_box_js,
+    confirmation_harness,
+    update_cached_input_songs,
+    PROGRESS_BAR,
+)
+
+
+def render(
+    dummy_deletion_checkbox: gr.Checkbox,
+    delete_confirmation: gr.State,
+    song_dir_dropdowns: list[gr.Dropdown],
+    cached_input_songs_dropdown: gr.Dropdown,
+    cached_input_songs_dropdown2: gr.Dropdown,
+    intermediate_audio_to_delete: gr.Dropdown,
+):
+    with gr.Tab("Delete audio"):
+        with gr.Row():
+            with gr.Column():
+                intermediate_audio_to_delete.render()
+                delete_intermediate_audio_btn = gr.Button(
+                    "Delete selected",
+                    variant="secondary",
+                )
+                delete_all_intermediate_audio_btn = gr.Button(
+                    "Delete all", variant="primary"
+                )
+            with gr.Row():
+                intermediate_audio_delete_msg = gr.Text(
+                    label="Output message", interactive=False
+                )
+
+        delete_intermediate_audio_click = delete_intermediate_audio_btn.click(
+            identity,
+            inputs=dummy_deletion_checkbox,
+            outputs=delete_confirmation,
+            js=confirm_box_js(
+                "Are you sure you want to delete intermediate audio files for the selected songs?"
+            ),
+            show_progress="hidden",
+        ).then(
+            partial(
+                confirmation_harness(delete_intermediate_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=[delete_confirmation, intermediate_audio_to_delete],
+            outputs=intermediate_audio_delete_msg,
+        )
+
+        delete_all_intermediate_audio_click = delete_all_intermediate_audio_btn.click(
+            identity,
+            inputs=dummy_deletion_checkbox,
+            outputs=delete_confirmation,
+            js=confirm_box_js(
+                "Are you sure you want to delete all intermediate audio files?"
+            ),
+            show_progress="hidden",
+        ).then(
+            partial(
+                confirmation_harness(delete_all_intermediate_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=delete_confirmation,
+            outputs=intermediate_audio_delete_msg,
+        )
+        for click_event in [
+            delete_intermediate_audio_click,
+            delete_all_intermediate_audio_click,
+        ]:
+            click_event.success(
+                partial(
+                    update_cached_input_songs,
+                    3 + len(song_dir_dropdowns),
+                    [],
+                    [0],
+                ),
+                outputs=[
+                    intermediate_audio_to_delete,
+                    cached_input_songs_dropdown,
+                    cached_input_songs_dropdown2,
+                    *song_dir_dropdowns,
+                ],
+                show_progress="hidden",
+            )

--- a/src/frontend/tabs/one_click_generation.py
+++ b/src/frontend/tabs/one_click_generation.py
@@ -9,20 +9,15 @@ from frontend.common import (
     EventArgs,
     setup_consecutive_event_listeners_with_toggled_interactivity,
     exception_harness,
-    confirmation_harness,
-    confirm_box_js,
     update_cached_input_songs,
     get_song_cover_name_harness,
     toggle_visible_component,
     show_hop_slider,
-    identity,
     update_value,
     PROGRESS_BAR,
 )
 
 from backend.generate_song_cover import (
-    delete_intermediate_audio,
-    delete_all_intermediate_audio,
     retrieve_song,
     separate_vocals,
     separate_main_vocals,
@@ -88,8 +83,6 @@ def _toggle_intermediate_files_accordion(
 
 
 def render(
-    dummy_deletion_checkbox: gr.Checkbox,
-    delete_confirmation: gr.State,
     generate_buttons: list[gr.Button],
     song_dir_dropdowns: list[gr.Dropdown],
     cached_input_songs_dropdown: gr.Dropdown,
@@ -317,74 +310,6 @@ def render(
                     value=False,
                     info="Show generated intermediate audio files when song cover generation completes. Leave unchecked to optimize performance.",
                 )
-            with gr.Accordion("Delete intermediate audio files", open=False):
-                with gr.Row():
-                    with gr.Column():
-                        intermediate_audio_to_delete.render()
-                        delete_intermediate_audio_btn = gr.Button(
-                            "Delete selected",
-                            variant="secondary",
-                        )
-                        delete_all_intermediate_audio_btn = gr.Button(
-                            "Delete all", variant="primary"
-                        )
-                    with gr.Row():
-                        intermediate_audio_delete_msg = gr.Text(
-                            label="Output message", interactive=False
-                        )
-
-                delete_intermediate_audio_click = delete_intermediate_audio_btn.click(
-                    identity,
-                    inputs=dummy_deletion_checkbox,
-                    outputs=delete_confirmation,
-                    js=confirm_box_js(
-                        "Are you sure you want to delete intermediate audio files for the selected songs?"
-                    ),
-                    show_progress="hidden",
-                ).then(
-                    partial(
-                        confirmation_harness(delete_intermediate_audio),
-                        progress_bar=PROGRESS_BAR,
-                    ),
-                    inputs=[delete_confirmation, intermediate_audio_to_delete],
-                    outputs=intermediate_audio_delete_msg,
-                )
-
-                delete_all_intermediate_audio_click = delete_all_intermediate_audio_btn.click(
-                    identity,
-                    inputs=dummy_deletion_checkbox,
-                    outputs=delete_confirmation,
-                    js=confirm_box_js(
-                        "Are you sure you want to delete all intermediate audio files?"
-                    ),
-                    show_progress="hidden",
-                ).then(
-                    partial(
-                        confirmation_harness(delete_all_intermediate_audio),
-                        progress_bar=PROGRESS_BAR,
-                    ),
-                    inputs=delete_confirmation,
-                    outputs=intermediate_audio_delete_msg,
-                )
-                for click_event in [
-                    delete_intermediate_audio_click,
-                    delete_all_intermediate_audio_click,
-                ]:
-                    click_event.success(
-                        partial(
-                            update_cached_input_songs,
-                            3 + len(song_dir_dropdowns),
-                            [],
-                            [0],
-                        ),
-                        outputs=[
-                            intermediate_audio_to_delete,
-                            cached_input_songs_dropdown,
-                            cached_input_songs_dropdown2,
-                            *song_dir_dropdowns,
-                        ],
-                        show_progress="hidden",
-                    )
         intermediate_audio_accordions = [
             gr.Accordion(label, open=False, render=False)
             for label in [

--- a/src/frontend/tabs/one_click_generation.py
+++ b/src/frontend/tabs/one_click_generation.py
@@ -286,6 +286,12 @@ def render(
                     value="mp3",
                     label="Output file format",
                 )
+            with gr.Row():
+                show_intermediate_files = gr.Checkbox(
+                    label="Show intermediate audio files",
+                    value=False,
+                    info="Show generated intermediate audio files when song cover generation completes. Leave unchecked to optimize performance.",
+                )
             rvc_model.change(
                 partial(get_song_cover_name_harness, None, update_key="placeholder"),
                 inputs=[cached_input_songs_dropdown, rvc_model],
@@ -298,18 +304,7 @@ def render(
                 outputs=output_name,
                 show_progress="hidden",
             )
-        with gr.Accordion("Intermediate audio options", open=False):
-            with gr.Row():
-                keep_files = gr.Checkbox(
-                    label="Keep intermediate audio files",
-                    value=True,
-                    info="Keep song directory with intermediate audio files generated during song cover generation. Leave unchecked to save space.",
-                )
-                show_intermediate_files = gr.Checkbox(
-                    label="Show intermediate audio files",
-                    value=False,
-                    info="Show generated intermediate audio files when song cover generation completes. Leave unchecked to optimize performance.",
-                )
+
         intermediate_audio_accordions = [
             gr.Accordion(label, open=False, render=False)
             for label in [
@@ -451,7 +446,6 @@ def render(
                     output_sr,
                     output_format,
                     output_name,
-                    keep_files,
                     show_intermediate_files,
                 ],
                 outputs=[
@@ -486,7 +480,7 @@ def render(
             generate_event_args_list,
             generate_buttons + [show_intermediate_files],
         )
-        percentages = [i / 16 for i in range(16)]
+        percentages = [i / 15 for i in range(15)]
 
         generate_btn2_event_args_list = [
             EventArgs(
@@ -587,7 +581,7 @@ def render(
             EventArgs(
                 partial(
                     _mix_song_cover_harness,
-                    percentages=percentages[13:16],
+                    percentages=percentages[13:15],
                 ),
                 inputs=[
                     postprocessed_vocals_track,
@@ -602,7 +596,6 @@ def render(
                     output_sr,
                     output_format,
                     output_name,
-                    keep_files,
                 ],
                 outputs=[song_cover_track],
             ),
@@ -642,7 +635,6 @@ def render(
                 0,
                 44100,
                 "mp3",
-                True,
                 False,
             ],
             outputs=[
@@ -663,7 +655,6 @@ def render(
                 backup_gain,
                 output_sr,
                 output_format,
-                keep_files,
                 show_intermediate_files,
             ],
             show_progress="hidden",


### PR DESCRIPTION
This PR moves the deletion of intermediate audio files functionality to a dedicated tab in webui. 

Additionally, this PR also removes the option to keep intermediate audio files, instead always keeping intermediate audio files. The option to show intermediate audio files  is still kept but moved into the `Audio output` accordion in the webui (this might not be the best place for it, but it  will make do for now)