### PR TITLE
fix .bat launcher script

### DIFF
--- a/src/extra_typing.py
+++ b/src/extra_typing.py
@@ -68,28 +68,36 @@ class TransferUpdateArgs(TypedDict, total=False):
     value: str | None
 
 
-MixSongCoverHarnessArgs = tuple[str, int, int, int, int, InputAudioExt, str]
+MixSongCoverHarnessArgs = tuple[
+    str,  # song_dir
+    int,  # main_gain
+    int,  # inst_gain
+    int,  # backup_gain
+    int,  # output_sr
+    InputAudioExt,  # output_format
+    str,  # output_name
+]
 
 RunPipelineHarnessArgs = tuple[
-    str,
-    str,
-    int,
-    int,
-    float,
-    int,
-    float,
-    float,
-    F0Method,
-    int,
-    float,
-    float,
-    float,
-    float,
-    int,
-    int,
-    int,
-    int,
-    InputAudioExt,
-    str,
-    bool,
+    str,  # song_input
+    str,  # voice_model
+    int,  # pitch_change_vocals
+    int,  # pitch_change_all
+    float,  # index_rate
+    int,  # filter_radius
+    float,  # rms_mix_rate
+    float,  # protect
+    F0Method,  # f0_method
+    int,  # crepe_hop_length
+    float,  # reverb_rm_size
+    float,  # reverb_wet
+    float,  # reverb_dry
+    float,  # reverb_damping
+    int,  # main_gain
+    int,  # inst_gain
+    int,  # backup_gain
+    int,  # output_sr
+    InputAudioExt,  # output_format
+    str,  # output_name
+    bool,  # return_files
 ]

--- a/urvc.bat
+++ b/urvc.bat
@@ -65,6 +65,8 @@ if "%1" == "install" (
     if not exist "%CONDA_EXE_DIR%" (
         echo Installing Miniconda to %CONDA_ROOT%...
         start /wait "" miniconda3_11.exe /InstallationType=JustMe /RegisterPython=0 /S /D=%CONDA_ROOT%
+    )
+    if exist miniconda3_11.exe (
         del miniconda3_11.exe
     )
     cd %ROOT%


### PR DESCRIPTION
Fixes .bat launcher script for windows, so that miniconda executable is removed once it is no longer needed. 

Additionally, this PR also adds comments to type aliases `MixSongCoverHarnessArgs`  `RunPipelineHarnessArgs` explaining what parameter each type value represents. 