### PR TITLE
upgrade to python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,8 @@ sox==1.4.1
 
 # Machine learning
 git+https://github.com/JackismyShephard/fairseq; sys_platform == 'linux'
-fairseq==0.12.2; sys_platform == 'darwin' or sys_platform == 'win32'
+./dependencies/fairseq-0.12.3.1-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
+./dependencies/diffq-0.2.4-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.1.1+cu118 # NOTE upgraded from 2.0.1+cu118
 torchcrepe==0.0.23 # NOTE upgraded from 0.0.20

--- a/urvc.bat
+++ b/urvc.bat
@@ -54,14 +54,7 @@ if "%1" == "install" (
         echo "%URL_MAIN%/dependencies.zip"
         exit /b 1
     )
-
-    echo.
-    echo Installing Visual Studio Build Tools. This might take a while...
     cd %DEPENDENCIES_DIR%
-    start /wait "" vs.exe --wait --quiet --norestart --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041
-    echo Visual Studio Build Tools successfully installed.
-    del vs.exe
-
     if not exist "%CONDA_EXE_DIR%" (
         echo Installing Miniconda to %CONDA_ROOT%...
         start /wait "" miniconda3_11.exe /InstallationType=JustMe /RegisterPython=0 /S /D=%CONDA_ROOT%
@@ -71,7 +64,7 @@ if "%1" == "install" (
     )
     cd %ROOT%
 
-    call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.10
+    call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.11
     call activate.bat %VIRTUAL_ENV_DIR%
     echo Installing Python packages..
     REM installing vs2015_runtime is necessary due to conda using an old vc runtime 
@@ -111,7 +104,7 @@ if "%1" == "update" (
     git pull
     call activate.bat
     call conda remove --prefix %VIRTUAL_ENV_DIR% --all --yes
-    call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.10
+    call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.11
     call conda activate %VIRTUAL_ENV_DIR%
     call conda install -y -c conda-forge vs2015_runtime faiss-cpu
     pip cache purge

--- a/urvc.sh
+++ b/urvc.sh
@@ -11,10 +11,10 @@ main() {
             install_distro_specifics
             install_cuda_118
             sudo add-apt-repository -y ppa:deadsnakes/ppa
-            sudo apt install -y python3.10 python3.10-dev python3.10-venv
+            sudo apt install -y python3.11 python3.11-dev python3.11-venv
             sudo apt install -y sox libsox-dev ffmpeg
 
-            python3.10 -m venv .venv --upgrade-deps 
+            python3.11 -m venv .venv --upgrade-deps 
             . .venv/bin/activate
             pip cache purge
             pip install -r requirements.txt
@@ -36,7 +36,7 @@ main() {
             echo "Updating Ultimate RVC"
             git pull
             rm -rf .venv
-            python3.10 -m venv .venv --upgrade-deps
+            python3.11 -m venv .venv --upgrade-deps
             . .venv/bin/activate
             pip cache purge
             pip install -r requirements.txt


### PR DESCRIPTION
upgrades python used by app to version 3.11. At the same time, also eliminates the need for installing Visual Studio build tools on windows. Instead, wheels requiring Visual Studio Build tools to compile are pre-compiled and downloaded from a remote repository.