### PR TITLE
fix setuptools bug

### DIFF
--- a/urvc.bat
+++ b/urvc.bat
@@ -71,7 +71,7 @@ if "%1" == "install" (
     REM that is not compatible with new visual studio compiler
     call conda install -y -c conda-forge faiss-cpu vs2015_runtime
     pip cache purge
-    pip install --upgrade setuptools
+    pip install --upgrade pip setuptools<72.0.0
     pip install -r "%ROOT%\requirements.txt"
 
     echo.
@@ -108,7 +108,7 @@ if "%1" == "update" (
     call conda activate %VIRTUAL_ENV_DIR%
     call conda install -y -c conda-forge vs2015_runtime faiss-cpu
     pip cache purge
-    pip install --upgrade setuptools
+    pip install --upgrade pip setuptools<72.0.0
     pip install -r "%ROOT%\requirements.txt"
     call conda deactivate
 

--- a/urvc.sh
+++ b/urvc.sh
@@ -14,9 +14,10 @@ main() {
             sudo apt install -y python3.11 python3.11-dev python3.11-venv
             sudo apt install -y sox libsox-dev ffmpeg
 
-            python3.11 -m venv .venv --upgrade-deps 
+            python3.11 -m venv .venv
             . .venv/bin/activate
             pip cache purge
+            pip install --upgrade pip setuptools<72.0.0
             pip install -r requirements.txt
             pip install faiss-cpu==1.7.3
             pip uninstall torch torchaudio -y
@@ -36,9 +37,10 @@ main() {
             echo "Updating Ultimate RVC"
             git pull
             rm -rf .venv
-            python3.11 -m venv .venv --upgrade-deps
+            python3.11 -m venv .venv
             . .venv/bin/activate
             pip cache purge
+            pip install --upgrade pip setuptools<72.0.0
             pip install -r requirements.txt
             pip install faiss-cpu==1.7.3
             pip uninstall torch torchaudio -y


### PR DESCRIPTION
Currently `setuptools` package cannot be upgraded via pip due to an error introduced in its latest version. This PR fixes that by pinning `setuptools` to a prior version. More information can be found here: https://stackoverflow.com/questions/78806100/no-module-named-setuptools-command-test