### PR TITLE
fix matplotlib package installation errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,8 +39,9 @@ torchcrepe==0.0.23 # NOTE upgraded from 0.0.20
 
 # Visualization
 gradio==4.39.0
+matplotlib==3.9.0
 #TODO add these later
-#matplotlib==3.7.2
+
 #tensorboard
 
 # Miscellaneous

--- a/urvc.bat
+++ b/urvc.bat
@@ -67,11 +67,9 @@ if "%1" == "install" (
     call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.11
     call activate.bat %VIRTUAL_ENV_DIR%
     echo Installing Python packages..
-    REM installing vs2015_runtime is necessary due to conda using an old vc runtime 
-    REM that is not compatible with new visual studio compiler
-    call conda install -y -c conda-forge faiss-cpu vs2015_runtime
+    call conda install -y -c conda-forge faiss-cpu
     pip cache purge
-    pip install --upgrade pip "setuptools<72.0.0"
+    python -m pip install --upgrade pip setuptools
     pip install -r "%ROOT%\requirements.txt"
 
     echo.
@@ -106,9 +104,9 @@ if "%1" == "update" (
     call conda remove --prefix %VIRTUAL_ENV_DIR% --all --yes
     call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.11
     call conda activate %VIRTUAL_ENV_DIR%
-    call conda install -y -c conda-forge vs2015_runtime faiss-cpu
+    call conda install -y -c conda-forge faiss-cpu
     pip cache purge
-    pip install --upgrade pip "setuptools<72.0.0"
+    python -m pip install --upgrade pip setuptools
     pip install -r "%ROOT%\requirements.txt"
     call conda deactivate
 

--- a/urvc.sh
+++ b/urvc.sh
@@ -14,10 +14,9 @@ main() {
             sudo apt install -y python3.11 python3.11-dev python3.11-venv
             sudo apt install -y sox libsox-dev ffmpeg
 
-            python3.11 -m venv .venv
+            python3.11 -m venv .venv --upgrade-deps
             . .venv/bin/activate
             pip cache purge
-            pip install --upgrade pip "setuptools<72.0.0"
             pip install -r requirements.txt
             pip install faiss-cpu==1.7.3
             pip uninstall torch torchaudio -y
@@ -37,10 +36,9 @@ main() {
             echo "Updating Ultimate RVC"
             git pull
             rm -rf .venv
-            python3.11 -m venv .venv
+            python3.11 -m venv .venv --upgrade-deps
             . .venv/bin/activate
             pip cache purge
-            pip install --upgrade pip "setuptools<72.0.0"
             pip install -r requirements.txt
             pip install faiss-cpu==1.7.3
             pip uninstall torch torchaudio -y


### PR DESCRIPTION
Pins `matplotlib` package at version `3.9.0` to avoid build errors due to `meson`. Also removes unnecesary pinning of `setuptools`