### PR TITLE
use gpu acceleration as default for colab notebook

### DIFF
--- a/notebooks/ultimate_rvc_colab.ipynb
+++ b/notebooks/ultimate_rvc_colab.ipynb
@@ -15,7 +15,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "colab": {
@@ -127,7 +127,8 @@
   ],
   "metadata": {
     "colab": {
-      "provenance": []
+      "provenance": [],
+      "gpuType": "T4"
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -135,7 +136,8 @@
     },
     "language_info": {
       "name": "python"
-    }
+    },
+    "accelerator": "GPU"
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
Update metadata of colab notebook so that T4 GPU acceleration is turned on by default.