### PR TITLE
Remove generate button 2 and related functionality

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -84,21 +84,19 @@ with gr.Blocks(title="Ultimate RVC") as app:
         gr.Button(
             label,
             variant="primary",
-            visible=visible,
             render=False,
             scale=scale,
         )
-        for label, visible, scale, in [
-            ("Retrieve song", True, 1),
-            ("Separate vocals/instrumentals", True, 1),
-            ("Separate main/backup vocals", True, 1),
-            ("De-reverb vocals", True, 1),
-            ("Convert vocals", True, 1),
-            ("Post-process vocals", True, 1),
-            ("Pitch shift background", True, 1),
-            ("Mix song cover", True, 1),
-            ("Generate", True, 2),
-            ("Generate step-by-step", False, 1),
+        for label, scale, in [
+            ("Retrieve song", 1),
+            ("Separate vocals/instrumentals", 1),
+            ("Separate main/backup vocals", 1),
+            ("De-reverb vocals", 1),
+            ("Convert vocals", 1),
+            ("Post-process vocals", 1),
+            ("Pitch shift background", 1),
+            ("Mix song cover", 1),
+            ("Generate", 2),
         ]
     ]
 

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -165,7 +165,7 @@ def setup_consecutive_event_listeners(
         raise ValueError("Event args list must not be empty.")
     dependency = component
     for event_args in event_args_list:
-        event_listener: Callable[..., Dependency] = getattr(dependency, event_args.name)
+        event_listener = getattr(dependency, event_args.name)
         dependency = event_listener(
             event_args.fn,
             inputs=event_args.inputs,

--- a/src/frontend/tabs/manage_audio.py
+++ b/src/frontend/tabs/manage_audio.py
@@ -40,7 +40,7 @@ def render(
                         "Delete all", variant="primary"
                     )
                 with gr.Row():
-                    intermediate_audio_delete_msg = gr.Text(
+                    intermediate_audio_delete_msg = gr.Textbox(
                         label="Output message", interactive=False
                     )
         with gr.Accordion("Output audio", open=False):
@@ -54,13 +54,13 @@ def render(
                         "Delete all", variant="primary"
                     )
                 with gr.Row():
-                    output_audio_delete_msg = gr.Text(
+                    output_audio_delete_msg = gr.Textbox(
                         label="Output message", interactive=False
                     )
         with gr.Accordion("All audio", open=True):
             with gr.Row():
                 delete_all_audio_btn = gr.Button("Delete", variant="primary")
-                delete_all_audio_msg = gr.Text(
+                delete_all_audio_msg = gr.Textbox(
                     label="Output message", interactive=False
                 )
 

--- a/src/frontend/tabs/manage_models.py
+++ b/src/frontend/tabs/manage_models.py
@@ -73,7 +73,7 @@ def render(
                 label="Show voice models with tags",
                 choices=load_public_model_tags(),
             )
-            search_query = gr.Text(label="Search")
+            search_query = gr.Textbox(label="Search")
 
             public_models_table = gr.DataFrame(
                 value=load_public_models_table([]),
@@ -90,18 +90,18 @@ def render(
             )
 
         with gr.Row():
-            model_zip_link = gr.Text(
+            model_zip_link = gr.Textbox(
                 label="Download link to model",
                 info="Should point to a zip file containing a .pth model file and an optional .index file.",
             )
-            model_name = gr.Text(
+            model_name = gr.Textbox(
                 label="Model name",
                 info="Enter a unique name for the model.",
             )
 
         with gr.Row():
             download_btn = gr.Button("Download 🌐", variant="primary", scale=19)
-            dl_output_message = gr.Text(
+            dl_output_message = gr.Textbox(
                 label="Output message", interactive=False, scale=20
             )
 
@@ -154,11 +154,11 @@ def render(
             with gr.Column():
                 model_files = gr.File(label="Files", file_count="multiple")
 
-            local_model_name = gr.Text(label="Model name")
+            local_model_name = gr.Textbox(label="Model name")
 
         with gr.Row():
             model_upload_button = gr.Button("Upload model", variant="primary", scale=19)
-            local_upload_output_message = gr.Text(
+            local_upload_output_message = gr.Textbox(
                 label="Output message", interactive=False, scale=20
             )
             model_upload_button_click = model_upload_button.click(
@@ -174,7 +174,7 @@ def render(
             with gr.Column():
                 rvc_models_to_delete.render()
             with gr.Column():
-                rvc_models_deleted_message = gr.Text(
+                rvc_models_deleted_message = gr.Textbox(
                     label="Output message", interactive=False
                 )
 

--- a/src/frontend/tabs/multi_step_generation.py
+++ b/src/frontend/tabs/multi_step_generation.py
@@ -60,7 +60,6 @@ def render(
             pitch_shift_background_btn,
             mix_btn,
             _,
-            _,
         ) = generate_buttons
         (
             separate_vocals_dir,
@@ -228,7 +227,7 @@ def render(
                         type="index",
                     )
                 with gr.Column():
-                    song_input = gr.Text(
+                    song_input = gr.Textbox(
                         label="Song input",
                         info="Link to a song on YouTube or the full path of a local audio file.",
                     )
@@ -825,7 +824,7 @@ def render(
                 inst_gain = gr.Slider(-20, 20, value=0, step=1, label="Instrumentals")
                 backup_gain = gr.Slider(-20, 20, value=0, step=1, label="Backup vocals")
             with gr.Row():
-                output_name = gr.Text(
+                output_name = gr.Textbox(
                     label="Output file name",
                     placeholder="Ultimate RVC song cover",
                 )

--- a/src/typings/extra.py
+++ b/src/typings/extra.py
@@ -61,16 +61,6 @@ class TransferUpdateArgs(TypedDict, total=False):
     value: str | None
 
 
-MixSongCoverHarnessArgs = tuple[
-    str,  # song_dir
-    int,  # main_gain
-    int,  # inst_gain
-    int,  # backup_gain
-    int,  # output_sr
-    InputAudioExt,  # output_format
-    str,  # output_name
-]
-
 RunPipelineHarnessArgs = tuple[
     str,  # song_input
     str,  # voice_model


### PR DESCRIPTION
It does not make sense to keep the hidden generate button in the "one-click-generation" tab, as there are too many bugs associated with running its event listener. Hence this PR removes that button, including all its related event listener and all related helper functions. 

Additionally, this PR also updates all instances of `gr.Text` to be `gr.TextBox` (the former is simply an alias for the latter) 