### PR TITLE
add input validation to song cover generation pipeline function

### DIFF
--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -970,6 +970,14 @@ def run_pipeline(
     return_files: bool = False,
     progress_bar: gr.Progress | None = None,
 ) -> str | tuple[str, ...]:
+    if not song_input:
+        raise InputMissingError(
+            "Song input missing! Please provide a valid YouTube url, local audio file or cached input song."
+        )
+    if not voice_model:
+        raise InputMissingError("Voice model missing!")
+    if not os.path.isdir(os.path.join(RVC_MODELS_DIR, voice_model)):
+        raise PathNotFoundError("Voice model does not exist!")
     display_progress("[~] Starting song cover generation pipeline...", 0, progress_bar)
     percentages = [i / 15 for i in range(15)]
     orig_song_path, song_dir = retrieve_song(song_input, progress_bar, percentages[:3])

--- a/urvc.bat
+++ b/urvc.bat
@@ -67,7 +67,7 @@ if "%1" == "install" (
     call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.11
     call activate.bat %VIRTUAL_ENV_DIR%
     echo Installing Python packages..
-    call conda install -y -c conda-forge faiss-cpu
+    call conda install -y -c conda-forge faiss-cpu==1.7.3
     pip cache purge
     python -m pip install --upgrade pip setuptools
     pip install -r "%ROOT%\requirements.txt"
@@ -104,7 +104,7 @@ if "%1" == "update" (
     call conda remove --prefix %VIRTUAL_ENV_DIR% --all --yes
     call conda create --no-shortcuts -y -k --prefix %VIRTUAL_ENV_DIR% python=3.11
     call conda activate %VIRTUAL_ENV_DIR%
-    call conda install -y -c conda-forge faiss-cpu
+    call conda install -y -c conda-forge faiss-cpu==1.7.3
     pip cache purge
     python -m pip install --upgrade pip setuptools
     pip install -r "%ROOT%\requirements.txt"


### PR DESCRIPTION
Adds explicit validation of song input and rvc model name at the beginning of the `generate_song_cover.run_pipeline` function. This is done mainly to fail fast when a user has forgot to supply an RVC model name in the UI

Additionally, this PR also pins the version of `faiss-cpu` to `1.7.3` for windows (the same version that is used for linux). This seems to solve some spurious errors with faiss AVX2 not working. 