### PR TITLE
fix potential error when downloading huggingface model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ultimate RVC
 
-An extension of [AiCoverGen](https://github.com/SociallyIneptWeeb/AICoverGen), which provides several new features and improvements, enabling users to generate song covers using RVC with ease. Ideal for people who wnat to incorporate singing functionality into their AI assistant/chatbot/vtuber, or for people who want to hear their favourite characters sing their favourite song.
+An extension of [AiCoverGen](https://github.com/SociallyIneptWeeb/AICoverGen), which provides several new features and improvements, enabling users to generate song covers using RVC with ease. Ideal for people who want to incorporate singing functionality into their AI assistant/chatbot/vtuber, or for people who want to hear their favourite characters sing their favourite song.
 
 <!-- Showcase: TBA -->
 

--- a/src/backend/manage_voice_models.py
+++ b/src/backend/manage_voice_models.py
@@ -4,6 +4,7 @@ import shutil
 import gradio as gr
 import urllib.request
 import zipfile
+import re
 
 from common import RVC_MODELS_DIR
 from backend.exceptions import (
@@ -145,6 +146,16 @@ def download_online_model(
             f'Voice model directory "{dir_name}" already exists! Choose a different name for your voice model.'
         )
     zip_name = url.split("/")[-1].split("?")[0]
+
+    # NOTE in case huggingface link is a direct link rather
+    # than a resolve link then convert it to a resolve link
+    url = re.sub(
+        r"https://huggingface.co/([^/]+)/([^/]+)/blob/(.*)",
+        r"https://huggingface.co/\1/\2/resolve/\3",
+        url,
+    )
+
+    print(url)
 
     if "pixeldrain.com" in url:
         url = f"https://pixeldrain.com/api/file/{zip_name}"


### PR DESCRIPTION
Fixes error when downloading from huggingface from an url that contains `/blob/` instead of `/resolve/`.

Also fixes a typo in README