### PR TITLE
Add docstrings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,13 @@
+"""
+Main application for the Ultimate RVC project.
+
+Each tab of the application is defined in a separate module 
+in the `frontend/tabs` directory.
+
+Components that are accessed across multiple tabs are passed as arguments
+to the render functions in the respective modules.
+"""
+
 import os
 from argparse import ArgumentParser
 
@@ -18,6 +28,16 @@ from frontend.tabs.manage_audio import render as render_manage_audio_tab
 
 
 def _init_app() -> tuple[gr.Dropdown, ...]:
+    """
+    Initialize app by deleting any existing Gradio temp directory
+    and updating the choices of all dropdowns.
+
+    Returns
+    -------
+    tuple[gr.Dropdown, ...]
+        Updated dropdowns for selecting voice models, song directories,
+        and output audio files.
+    """
     delete_gradio_temp_dir()
     updated_rvc_model_dropdowns = tuple(
         gr.Dropdown(choices=get_current_models()) for _ in range(3)
@@ -52,7 +72,7 @@ with gr.Blocks(title="Ultimate RVC") as app:
         )
         for _ in range(7)
     ]
-    cached_input_songs_dropdown, cached_input_songs_dropdown2 = [
+    cached_input_songs_dropdown_1click, cached_input_songs_dropdown_multi = [
         gr.Dropdown(
             label="Song input",
             info="Select a song from the list of cached songs.",
@@ -73,7 +93,7 @@ with gr.Blocks(title="Ultimate RVC") as app:
         info="Select one or more output audio files to delete.",
         render=False,
     )
-    rvc_model, rvc_model2 = [
+    rvc_model_1click, rvc_model_multi = [
         gr.Dropdown(label="Voice model", render=False) for _ in range(2)
     ]
     rvc_models_to_delete = gr.Dropdown(
@@ -100,18 +120,18 @@ with gr.Blocks(title="Ultimate RVC") as app:
         render_one_click_tab(
             generate_buttons,
             song_dir_dropdowns,
-            cached_input_songs_dropdown,
-            cached_input_songs_dropdown2,
-            rvc_model,
+            cached_input_songs_dropdown_1click,
+            cached_input_songs_dropdown_multi,
+            rvc_model_1click,
             intermediate_audio_to_delete,
             output_audio_to_delete,
         )
         render_multi_step_tab(
             generate_buttons,
             song_dir_dropdowns,
-            cached_input_songs_dropdown,
-            cached_input_songs_dropdown2,
-            rvc_model2,
+            cached_input_songs_dropdown_1click,
+            cached_input_songs_dropdown_multi,
+            rvc_model_multi,
             intermediate_audio_to_delete,
             output_audio_to_delete,
         )
@@ -120,8 +140,8 @@ with gr.Blocks(title="Ultimate RVC") as app:
             dummy_deletion_checkbox,
             delete_confirmation,
             rvc_models_to_delete,
-            rvc_model,
-            rvc_model2,
+            rvc_model_1click,
+            rvc_model_multi,
         )
     with gr.Tab("Manage audio"):
 
@@ -129,8 +149,8 @@ with gr.Blocks(title="Ultimate RVC") as app:
             dummy_deletion_checkbox,
             delete_confirmation,
             song_dir_dropdowns,
-            cached_input_songs_dropdown,
-            cached_input_songs_dropdown2,
+            cached_input_songs_dropdown_1click,
+            cached_input_songs_dropdown_multi,
             intermediate_audio_to_delete,
             output_audio_to_delete,
         )
@@ -138,12 +158,12 @@ with gr.Blocks(title="Ultimate RVC") as app:
     app.load(
         _init_app,
         outputs=[
-            rvc_model,
-            rvc_model2,
+            rvc_model_1click,
+            rvc_model_multi,
             rvc_models_to_delete,
             intermediate_audio_to_delete,
-            cached_input_songs_dropdown,
-            cached_input_songs_dropdown2,
+            cached_input_songs_dropdown_1click,
+            cached_input_songs_dropdown_multi,
             *song_dir_dropdowns,
             output_audio_to_delete,
         ],

--- a/src/backend/common.py
+++ b/src/backend/common.py
@@ -1,3 +1,5 @@
+"""Common utility functions for the backend."""
+
 from typing import Any
 from typings.extra import StrOrBytesPath
 import gradio as gr
@@ -17,6 +19,18 @@ def display_progress(
     percentage: float | None = None,
     progress_bar: gr.Progress | None = None,
 ) -> None:
+    """
+    Display progress message and percentage in console or Gradio progress bar.
+
+    Parameters
+    ----------
+    message : str
+        Message to display.
+    percentage : float, optional
+        Percentage to display.
+    progress_bar : gr.Progress, optional
+        The Gradio progress bar to update.
+    """
     if progress_bar is None:
         print(message)
     else:
@@ -24,6 +38,21 @@ def display_progress(
 
 
 def remove_suffix_after(text: str, occurrence: str) -> str:
+    """
+    Remove suffix after the first occurrence of a substring in a string.
+
+    Parameters
+    ----------
+    text : str
+        The string to remove the suffix from.
+    occurrence : str
+        The substring to remove the suffix after.
+
+    Returns
+    -------
+    str
+        The string with the suffix removed.
+    """
     location = text.rfind(occurrence)
     if location == -1:
         return text
@@ -32,6 +61,21 @@ def remove_suffix_after(text: str, occurrence: str) -> str:
 
 
 def copy_files_to_new_folder(file_paths: list[str], folder_path: str) -> None:
+    """
+    Copy files to a new folder.
+
+    Parameters
+    ----------
+    file_paths : list[str]
+        List of file paths to copy.
+    folder_path : str
+        Path of the folder to copy the files to.
+
+    Raises
+    ------
+    PathNotFoundError
+        If a file does not exist.
+    """
     os.makedirs(folder_path)
     for file_path in file_paths:
         if not os.path.exists(file_path):
@@ -42,16 +86,55 @@ def copy_files_to_new_folder(file_paths: list[str], folder_path: str) -> None:
 
 
 def get_path_stem(path: str) -> str:
+    """
+    Get the stem of a file path.
+
+    The stem is the name of the file that the path points to,
+    not including its extension.
+
+    Parameters
+    ----------
+    path : str
+        The file path.
+
+    Returns
+    -------
+    str
+        The stem of the file path.
+    """
     return os.path.splitext(os.path.basename(path))[0]
 
 
 def json_dumps(thing: Any) -> str:
+    """
+    Dump a Python object to a JSON string.
+
+    Parameters
+    ----------
+    thing : Any
+        The object to dump.
+
+    Returns
+    -------
+    str
+        The JSON string representation of the object.
+    """
     return json.dumps(
         thing, ensure_ascii=False, sort_keys=True, indent=4, separators=(",", ": ")
     )
 
 
 def json_dump(thing: Any, path: StrOrBytesPath) -> None:
+    """
+    Dump a Python object to a JSON file.
+
+    Parameters
+    ----------
+    thing : Any
+        The object to dump.
+    path : str
+        The path of the JSON file.
+    """
     with open(path, "w", encoding="utf-8") as file:
         json.dump(
             thing,
@@ -64,11 +147,41 @@ def json_dump(thing: Any, path: StrOrBytesPath) -> None:
 
 
 def json_load(path: StrOrBytesPath, encoding: str = "utf-8") -> Any:
+    """
+    Load a Python object from a JSON file.
+
+    Parameters
+    ----------
+    path : str
+        The path of the JSON file.
+    encoding : str, default='utf-8'
+        The encoding of the file.
+
+    Returns
+    -------
+    Any
+        The Python object loaded from the JSON file.
+    """
     with open(path, encoding=encoding) as file:
         return json.load(file)
 
 
 def get_hash(thing: Any, size: int = 5) -> str:
+    """
+    Get a hash of a Python object.
+
+    Parameters
+    ----------
+    thing : Any
+        The object to hash.
+    size : int, default=5
+        The size of the hash in bytes.
+
+    Returns
+    -------
+    str
+        The hash of the object.
+    """
     return hashlib.blake2b(
         json_dumps(thing).encode("utf-8"), digest_size=size
     ).hexdigest()
@@ -76,16 +189,51 @@ def get_hash(thing: Any, size: int = 5) -> str:
 
 # TODO consider increasing size to 16
 # otherwise we might have problems with hash collisions
-# when using app as CLI
-# TODO use dedicated file_digest function once we upgradeto python 3.11
-# for better speedups
-def get_file_hash(filepath: StrOrBytesPath) -> str:
+def get_file_hash(filepath: StrOrBytesPath, size: int = 5) -> str:
+    """
+    Get the hash of a file.
+
+    Parameters
+    ----------
+    filepath : str
+        The path of the file.
+    size : int, default=5
+        The size of the hash in bytes.
+
+    Returns
+    -------
+    str
+        The hash of the file.
+    """
     with open(filepath, "rb") as f:
-        file_hash = hashlib.file_digest(f, "blake2b")
+        file_hash = hashlib.file_digest(f, lambda: hashlib.blake2b(digest_size=size))
     return file_hash.hexdigest()
 
 
 def get_rvc_model(voice_model: str) -> tuple[str, str]:
+    """
+    Get the RVC model file and optional index file for a voice model.
+
+    When no index file exists, an empty string is returned.
+
+    Parameters
+    ----------
+    voice_model : str
+        The name of the voice model.
+
+    Returns
+    -------
+    model_path : str
+        The path of the RVC model file.
+    index_path : str
+        The path of the RVC index file.
+
+    Raises
+    ------
+    PathNotFoundError
+        If the directory of the voice model does not exist or
+        if no model file exists in the directory.
+    """
     rvc_model_filename, rvc_index_filename = None, None
     model_dir = os.path.join(RVC_MODELS_DIR, voice_model)
     if not os.path.exists(model_dir):

--- a/src/backend/exceptions.py
+++ b/src/backend/exceptions.py
@@ -1,18 +1,43 @@
+"""
+This module contains custom exceptions that are raised by the backend.
+"""
+
+
 class InputMissingError(ValueError):
+    """
+    Raised when an input is missing.
+    """
+
     pass
 
 
 class InvalidPathError(OSError):
+    """
+    Raised when a path is invalid.
+    """
+
     pass
 
 
 class PathNotFoundError(OSError):
+    """
+    Raised when a path is not found.
+    """
+
     pass
 
 
 class PathExistsError(OSError):
+    """
+    Raised when a path already exists.
+    """
+
     pass
 
 
 class FileTypeError(ValueError):
+    """
+    Raised when a file is of the wrong type.
+    """
+
     pass

--- a/src/backend/manage_audio.py
+++ b/src/backend/manage_audio.py
@@ -1,3 +1,7 @@
+"""
+This module contains functions to manage audio files.
+"""
+
 import os
 from pathlib import PurePath
 import shutil
@@ -10,6 +14,14 @@ from common import GRADIO_TEMP_DIR
 
 
 def get_output_audio() -> list[tuple[str, str]]:
+    """
+    Get the name and path of all output audio files.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        A list of tuples containing the name and path of each output audio file.
+    """
     if os.path.isdir(OUTPUT_AUDIO_DIR):
         named_output_files = [
             (file_name, os.path.join(OUTPUT_AUDIO_DIR, file_name))
@@ -20,34 +32,74 @@ def get_output_audio() -> list[tuple[str, str]]:
 
 
 def delete_intermediate_audio(
-    song_inputs: list[str],
+    song_dirs: list[str],
     progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
-    if not song_inputs:
+    """
+    Delete intermediate audio files in provided song directories.
+
+    Parameters
+    ----------
+    song_dirs : list[str]
+        Paths of song directories to delete intermediate audio files for.
+    progress_bar : gr.Progress, optional
+        Gradio progress bar to update.
+    percentage : float, default=0.0
+        Percentage to display in the progress bar.
+
+    Returns
+    -------
+    str
+        Success message.
+
+    Raises
+    ------
+    InputMissingError
+        If no song directories are provided.
+    PathNotFoundError
+        If a song directory does not exist.
+    InvalidPathError
+        If a song directory is not located in the root of the intermediate audio directory.
+    """
+    if not song_dirs:
         raise InputMissingError(
-            "Song inputs missing! Please provide a non-empty list of song directories"
+            "Song directories missing! Please provide a non-empty list of song directories."
         )
     display_progress(
         "[~] Deleting intermediate audio files for selected songs...",
         percentage,
         progress_bar,
     )
-    for song_input in song_inputs:
-        if not os.path.isdir(song_input):
-            raise PathNotFoundError(f"Song directory '{song_input}' does not exist.")
+    for song_dir in song_dirs:
+        if not os.path.isdir(song_dir):
+            raise PathNotFoundError(f"Song directory '{song_dir}' does not exist.")
 
-        if not PurePath(song_input).parent == PurePath(INTERMEDIATE_AUDIO_DIR):
+        if not PurePath(song_dir).parent == PurePath(INTERMEDIATE_AUDIO_DIR):
             raise InvalidPathError(
-                f"Song directory '{song_input}' is not located in the intermediate audio root directory."
+                f"Song directory '{song_dir}' is not located in the root of the intermediate audio directory."
             )
-        shutil.rmtree(song_input)
+        shutil.rmtree(song_dir)
     return "[+] Successfully deleted intermediate audio files for selected songs!"
 
 
 def delete_all_intermediate_audio(
     progress_bar: gr.Progress | None = None, percentage: float = 0.0
 ) -> str:
+    """
+    Delete all intermediate audio files.
+
+    Parameters
+    ----------
+    progress_bar : gr.Progress, optional
+        Gradio progress bar to update.
+    percentage : float, default=0.0
+
+    Returns
+    -------
+    str
+        Success message.
+    """
     display_progress(
         "[~] Deleting all intermediate audio files...", percentage, progress_bar
     )
@@ -62,6 +114,32 @@ def delete_output_audio(
     progress_bar: gr.Progress | None = None,
     percentage: float = 0.0,
 ) -> str:
+    """
+    Delete selected output audio files.
+
+    Parameters
+    ----------
+    output_audio_files : list[str]
+        Paths of output audio files to delete.
+    progress_bar : gr.Progress, optional
+        Gradio progress bar to update.
+    percentage : float, default=0.0
+        Percentage to display in the progress bar.
+
+    Returns
+    -------
+    str
+        Success message.
+
+    Raises
+    ------
+    InputMissingError
+        If no output audio files are provided.
+    PathNotFoundError
+        If an output audio file does not exist.
+    InvalidPathError
+        If an output audio file is not located in the root of the output audio directory.
+    """
     if not output_audio_files:
         raise InputMissingError(
             "Output audio files missing! Please provide a non-empty list of output audio files."
@@ -76,7 +154,7 @@ def delete_output_audio(
             )
         if not PurePath(output_audio_file).parent == PurePath(OUTPUT_AUDIO_DIR):
             raise InvalidPathError(
-                f"Output audio file '{output_audio_file}' is not located in the output audio root directory."
+                f"Output audio file '{output_audio_file}' is not located in the root of the output audio directory."
             )
         os.remove(output_audio_file)
     return "[+] Successfully deleted selected output audio files!"
@@ -85,6 +163,21 @@ def delete_output_audio(
 def delete_all_output_audio(
     progress_bar: gr.Progress | None = None, percentage: float = 0.0
 ) -> str:
+    """
+    Delete all output audio files.
+
+    Parameters
+    ----------
+    progress_bar : gr.Progress, optional
+        Gradio progress bar to update.
+    percentage : float, default=0.0
+        Percentage to display in the progress bar.
+
+    Returns
+    -------
+    str
+        Success message.
+    """
     display_progress("[~] Deleting all output audio files...", percentage, progress_bar)
     if os.path.isdir(OUTPUT_AUDIO_DIR):
         shutil.rmtree(OUTPUT_AUDIO_DIR)
@@ -95,6 +188,21 @@ def delete_all_output_audio(
 def delete_all_audio(
     progress_bar: gr.Progress | None = None, percentage: float = 0.0
 ) -> str:
+    """
+    Delete all audio files.
+
+    Parameters
+    ----------
+    progress_bar : gr.Progress, optional
+        Gradio progress bar to update.
+    percentage : float, default=0.0
+        Percentage to display in the progress bar.
+
+    Returns
+    -------
+    str
+        Success message.
+    """
     display_progress("[~] Deleting all audio files...", percentage, progress_bar)
     if os.path.isdir(INTERMEDIATE_AUDIO_DIR):
         shutil.rmtree(INTERMEDIATE_AUDIO_DIR)
@@ -105,5 +213,8 @@ def delete_all_audio(
 
 
 def delete_gradio_temp_dir() -> None:
+    """
+    Delete the directory where Gradio stores temporary files.
+    """
     if os.path.isdir(GRADIO_TEMP_DIR):
         shutil.rmtree(GRADIO_TEMP_DIR)

--- a/src/common.py
+++ b/src/common.py
@@ -1,3 +1,5 @@
+"""Common variables used in the Ultimate-RVC project."""
+
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -1,8 +1,11 @@
+"""
+Module containing common utility functions and classes for the frontend.
+"""
+
 from typing import Callable, Literal, Any, Sequence, Concatenate
 from typings.extra import (
     P,
     T,
-    SongCoverNameUpdateKey,
     F0Method,
     DropdownChoices,
     DropdownValue,
@@ -25,6 +28,21 @@ PROGRESS_BAR = gr.Progress()
 
 
 def exception_harness(fun: Callable[P, T]) -> Callable[P, T]:
+    """
+    Wrap a function in a harness that catches exceptions
+    and re-raises them as instances of `gradio.Error`.
+
+    Parameters
+    ----------
+    fun : Callable[P, T]
+        The function to wrap.
+
+    Returns
+    -------
+    Callable[P, T]
+        The wrapped function.
+    """
+
     def _wrapped_fun(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return fun(*args, **kwargs)
@@ -35,6 +53,22 @@ def exception_harness(fun: Callable[P, T]) -> Callable[P, T]:
 
 
 def confirmation_harness(fun: Callable[P, T]) -> Callable[Concatenate[bool, P], T]:
+    """
+    Wrap a function in a harness that requires a confirmation
+    before executing and catches exceptions,
+    re-raising them as instances of `gradio.Error`.
+
+    Parameters
+    ----------
+    fun : Callable[P, T]
+        The function to wrap.
+
+    Returns
+    -------
+    Callable[Concatenate[bool, P], T]
+        The wrapped function.
+    """
+
     def _wrapped_fun(confirm: bool, *args: P.args, **kwargs: P.kwargs) -> T:
         if confirm:
             return exception_harness(fun)(*args, **kwargs)
@@ -45,15 +79,54 @@ def confirmation_harness(fun: Callable[P, T]) -> Callable[Concatenate[bool, P], 
 
 
 def confirm_box_js(msg: str) -> str:
+    """
+    Generate JavaScript code for a confirmation box.
+
+    Parameters
+    ----------
+    msg : str
+        Message to display in the confirmation box.
+
+    Returns
+    -------
+    str
+        JavaScript code for the confirmation box.
+    """
     formatted_msg = f"'{msg}'"
     return f"(x) => confirm({formatted_msg})"
 
 
 def identity(x: T) -> T:
+    """
+    Identity function.
+
+    Parameters
+    ----------
+    x : T
+        Value to return.
+
+    Returns
+    -------
+    T
+        The value.
+    """
     return x
 
 
 def update_value(x: Any) -> dict[str, Any]:
+    """
+    Update the value of a component.
+
+    Parameters
+    ----------
+    x : Any
+        New value for the component.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary which updates the value of the component.
+    """
     return gr.update(value=x)
 
 
@@ -65,6 +138,34 @@ def update_dropdowns(
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> gr.Dropdown | tuple[gr.Dropdown, ...]:
+    """
+    Update the choices and optionally the value of one or more dropdown components.
+
+    Parameters
+    ----------
+    fn : Callable[P, DropdownChoices]
+        Function to get updated choices for the dropdown components.
+    num_components : int
+        Number of dropdown components to update.
+    value : DropdownValue, optional
+        New value for dropdown components.
+    value_indices : Sequence[int], default=[]
+        Indices of dropdown components to update the value for.
+    args : P.args
+        Positional arguments to pass to the function used to update choices.
+    kwargs : P.kwargs
+        Keyword arguments to pass to the function used to update choices.
+
+    Returns
+    -------
+    gr.Dropdown|tuple[gr.Dropdown,...]
+        Updated dropdown component or components.
+
+    Raises
+    ------
+    ValueError
+        If value indices are not unique or if an index exceeds the number of components.
+    """
     if len(value_indices) != len(set(value_indices)):
         raise ValueError("Value indices must be unique.")
     if value_indices and max(value_indices) >= num_components:
@@ -87,18 +188,77 @@ def update_dropdowns(
 def update_cached_input_songs(
     num_components: int, value: DropdownValue = None, value_indices: Sequence[int] = []
 ) -> gr.Dropdown | tuple[gr.Dropdown, ...]:
+    """
+    Updates the choices of one or more dropdown components
+    to the current set of cached input songs.
+
+    Optionally updates the default value of one or more of these components.
+
+    Parameters
+    ----------
+    num_components : int
+        Number of dropdown components to update.
+    value : DropdownValue, optional
+        New value for dropdown components.
+    value_indices : Sequence[int], default=[]
+        Indices of dropdown components to update the value for.
+
+    Returns
+    -------
+    gr.Dropdown|tuple[gr.Dropdown,...]
+        Updated dropdown component or components.
+    """
     return update_dropdowns(get_named_song_dirs, num_components, value, value_indices)
 
 
 def update_output_audio(
     num_components: int, value: DropdownValue = None, value_indices: Sequence[int] = []
 ) -> gr.Dropdown | tuple[gr.Dropdown, ...]:
+    """
+    Updates the choices of one or more dropdown
+    components to the current set of output audio files.
+
+    Optionally updates the default value of one or more of these components.
+
+    Parameters
+    ----------
+    num_components : int
+        Number of dropdown components to update.
+    value : DropdownValue, optional
+        New value for dropdown components.
+    value_indices : Sequence[int], default=[]
+        Indices of dropdown components to update the value for.
+
+    Returns
+    -------
+    gr.Dropdown|tuple[gr.Dropdown,...]
+        Updated dropdown component or components.
+    """
     return update_dropdowns(get_output_audio, num_components, value, value_indices)
 
 
 def toggle_visible_component(
     num_components: int, visible_index: int
 ) -> dict[str, Any] | tuple[dict[str, Any], ...]:
+    """
+    Reveal a single component from a set of components.
+    All other components are hidden.
+
+    Parameters
+    ----------
+    num_components : int
+        Number of components to set visibility for.
+    visible_index : int
+        Index of the component to reveal.
+
+    Returns
+    -------
+    dict|tuple[dict,...]
+        A single dictionary or a tuple of dictionaries
+        that update the visibility of the components.
+    """
+    if visible_index >= num_components:
+        raise ValueError("Visible index must be less than number of components.")
     update_args: list[ComponentVisibilityKwArgs] = [
         {"visible": False, "value": None} for _ in range(num_components)
     ]
@@ -111,25 +271,82 @@ def toggle_visible_component(
 def _toggle_component_interactivity(
     num_components: int, interactive: bool
 ) -> dict[str, Any] | tuple[dict[str, Any], ...]:
+    """
+    Toggle interactivity of one or more components.
+
+    Parameters
+    ----------
+    num_components : int
+        Number of components to toggle interactivity for.
+    interactive : bool
+        Whether to make the components interactive or not.
+
+    Returns
+    -------
+    dict|tuple[dict,...]
+        A single dictionary or a tuple of dictionaries
+        that update the interactivity of the components.
+    """
     if num_components == 1:
         return gr.update(interactive=interactive)
     return tuple(gr.update(interactive=interactive) for _ in range(num_components))
 
 
 def show_hop_slider(pitch_detection_algo: F0Method) -> gr.Slider:
+    """
+    Show or hide a slider component based on the given pitch extraction algorithm.
+
+    Parameters
+    ----------
+    pitch_detection_algo : F0Method
+        Pitch detection algorithm to determine visibility of the slider.
+
+    Returns
+    -------
+    gr.Slider
+        Slider component with visibility set accordingly.
+    """
     if pitch_detection_algo == "mangio-crepe":
         return gr.Slider(visible=True)
     else:
         return gr.Slider(visible=False)
 
 
-def get_song_cover_name_harness(
+def update_song_cover_name(
     mixed_vocals: str | None = None,
     song_dir: str | None = None,
     voice_model: str | None = None,
-    update_key: SongCoverNameUpdateKey = "value",
+    update_placeholder: bool = False,
 ) -> gr.Textbox:
+    """
+    Updates a textbox component so that it displays a suitable name for a cover of
+    a given song.
+
+    If the path of an existing song directory is provided, the original song
+    name is inferred from that directory. If a voice model is not provided
+    but the path of an existing song directory and the path of a mixed vocals file
+    in that directory are provided, then the voice model is inferred from
+    the mixed vocals file.
+
+
+    Parameters
+    ----------
+    mixed_vocals : str, optional
+        The path to a mixed vocals file.
+    song_dir : str, optional
+        The path to a song directory.
+    voice_model : str, optional
+        The name of a voice model.
+    update_placeholder : bool, default=False
+        Whether to update the placeholder text of the textbox component.
+
+    Returns
+    -------
+    gr.Textbox
+        Updated textbox component.
+    """
     update_args: TextBoxArgs = {}
+    update_key = "placeholder" if update_placeholder else "value"
     if mixed_vocals or song_dir or voice_model:
         name = exception_harness(get_song_cover_name)(
             mixed_vocals, song_dir, voice_model, progress_bar=PROGRESS_BAR
@@ -142,6 +359,23 @@ def get_song_cover_name_harness(
 
 @dataclass
 class EventArgs:
+    """
+    Data class to store arguments for setting up event listeners.
+
+    Attributes
+    ----------
+    fn : Callable[..., Any]
+        Function to call when an event is triggered.
+    inputs : Sequence[Component], optional
+        Components to serve as inputs to the function.
+    outputs : Sequence[Component], optional
+        Components where to store the outputs of the function.
+    name : Literal["click", "success", "then"], default="success"
+        Name of the event to listen for.
+    show_progress : Literal["full", "minimal", "hidden"], default="full"
+        Level of progress bar to show when the event is triggered.
+    """
+
     fn: Callable[..., Any]
     inputs: Sequence[Component] | None = None
     outputs: Sequence[Component] | None = None
@@ -152,6 +386,21 @@ class EventArgs:
 def setup_consecutive_event_listeners(
     component: Component, event_args_list: list[EventArgs]
 ) -> Dependency | Component:
+    """
+    Set up a chain of event listeners on a component.
+
+    Parameters
+    ----------
+    component : Component
+        The component to set up event listeners on.
+    event_args_list : list[EventArgs]
+        List of event arguments to set up event listeners with.
+
+    Returns
+    -------
+    Dependency | Component
+        The last dependency in the chain of event listeners.
+    """
     if len(event_args_list) == 0:
         raise ValueError("Event args list must not be empty.")
     dependency = component
@@ -171,6 +420,31 @@ def setup_consecutive_event_listeners_with_toggled_interactivity(
     event_args_list: list[EventArgs],
     toggled_components: Sequence[Component],
 ) -> Dependency | Component:
+    """
+    Set up a chain of event listeners on a component
+    with interactivity toggled for a set of other components.
+
+    While the chain of event listeners is being executed,
+    the other components are made non-interactive.
+    When the chain of event listeners is completed,
+    the other components are made interactive again.
+
+    Parameters
+    ----------
+    component : Component
+        The component to set up event listeners on.
+
+    event_args_list : list[EventArgs]
+        List of event arguments to set up event listeners with.
+
+    toggled_components : Sequence[Component]
+        Components to toggle interactivity for.
+
+    Returns
+    -------
+    Dependency | Component
+        The last dependency in the chain of event listeners.
+    """
     if len(event_args_list) == 0:
         raise ValueError("Event args list must not be empty.")
 

--- a/src/frontend/tabs/manage_audio.py
+++ b/src/frontend/tabs/manage_audio.py
@@ -1,3 +1,7 @@
+"""
+This module contains the code for the "Delete audio" tab.
+"""
+
 from functools import partial
 import gradio as gr
 
@@ -22,11 +26,38 @@ def render(
     dummy_deletion_checkbox: gr.Checkbox,
     delete_confirmation: gr.State,
     song_dir_dropdowns: list[gr.Dropdown],
-    cached_input_songs_dropdown: gr.Dropdown,
-    cached_input_songs_dropdown2: gr.Dropdown,
+    cached_input_songs_dropdown_1click: gr.Dropdown,
+    cached_input_songs_dropdown_multi: gr.Dropdown,
     intermediate_audio_to_delete: gr.Dropdown,
     output_audio_to_delete: gr.Dropdown,
-):
+) -> None:
+    """
+    Render "Delete audio" tab.
+
+    Parameters
+    ----------
+    dummy_deletion_checkbox : gr.Checkbox
+        Dummy component needed for deletion confirmation in the
+        "Delete audio" tab and the "Manage models" tab.
+    delete_confirmation : gr.State
+        Component storing deletion confirmation status in the
+        "Delete audio" tab and the "Manage models" tab.
+    song_dir_dropdowns : list[gr.Dropdown]
+        Dropdowns for selecting song directories in the
+        "Multi-step generation" tab.
+    cached_input_songs_dropdown_1click : gr.Dropdown
+        Dropdown for selecting cached input songs in the
+        "One-click generation" tab
+    cached_input_songs_dropdown_multi : gr.Dropdown
+        Dropdown for selecting cached input songs in the
+        "Multi-step generation" tab
+    intermediate_audio_to_delete : gr.Dropdown
+        Dropdown for selecting intermediate audio files to delete in the
+        "Delete audio" tab.
+    output_audio_to_delete : gr.Dropdown
+        Dropdown for selecting output audio files to delete in the
+        "Delete audio" tab.
+    """
     with gr.Tab("Delete audio"):
         with gr.Accordion("Intermediate audio", open=False):
             with gr.Row():
@@ -152,8 +183,8 @@ def render(
                 ),
                 outputs=[
                     intermediate_audio_to_delete,
-                    cached_input_songs_dropdown,
-                    cached_input_songs_dropdown2,
+                    cached_input_songs_dropdown_1click,
+                    cached_input_songs_dropdown_multi,
                     *song_dir_dropdowns,
                 ],
                 show_progress="hidden",
@@ -174,8 +205,8 @@ def render(
             partial(update_cached_input_songs, 3 + len(song_dir_dropdowns), [], [0]),
             outputs=[
                 intermediate_audio_to_delete,
-                cached_input_songs_dropdown,
-                cached_input_songs_dropdown2,
+                cached_input_songs_dropdown_1click,
+                cached_input_songs_dropdown_multi,
                 *song_dir_dropdowns,
             ],
             show_progress="hidden",

--- a/src/frontend/tabs/manage_models.py
+++ b/src/frontend/tabs/manage_models.py
@@ -1,3 +1,7 @@
+"""
+This module contains the code for the "Manage models" tab.
+"""
+
 from typings.extra import DropdownValue
 from functools import partial
 
@@ -28,12 +32,49 @@ from backend.manage_voice_models import (
 def _update_model_lists(
     num_components: int, value: DropdownValue = None, value_indices: list[int] = []
 ) -> gr.Dropdown | tuple[gr.Dropdown, ...]:
+    """
+    Updates the choices of one or more dropdown
+    components to the current set of voice models.
+
+    Optionally updates the default value of one or more of these components.
+
+    Parameters
+    ----------
+    num_components : int
+        Number of dropdown components to update.
+    value : DropdownValue, optional
+        New value for dropdown components.
+    value_indices : list[int], default=[]
+        Indices of dropdown components to update the value for.
+
+    Returns
+    -------
+    gr.Dropdown | tuple[gr.Dropdown, ...]
+        Updated dropdown component or components.
+    """
     return update_dropdowns(get_current_models, num_components, value, value_indices)
 
 
 def _filter_public_models_table_harness(
     tags: list[str], query: str, progress_bar: gr.Progress
 ) -> gr.Dataframe:
+    """
+    Filter the public models table based on tags and search query.
+
+    Parameters
+    ----------
+    tags : list[str]
+        Tags to filter the table by.
+    query : str
+        Search query to filter the table by.
+    progress_bar : gr.Progress
+        Progress bar to display progress.
+
+    Returns
+    -------
+    gr.Dataframe
+        The filtered public models table rendered in a Gradio dataframe.
+    """
     models_table = filter_public_models_table(tags, query, progress_bar)
     return gr.Dataframe(value=models_table)
 
@@ -41,6 +82,23 @@ def _filter_public_models_table_harness(
 def _pub_dl_autofill(
     pub_models: pd.DataFrame, event: gr.SelectData
 ) -> tuple[gr.Textbox, gr.Textbox]:
+    """
+    Autofill download link and model name based on selected row in public models table.
+
+    Parameters
+    ----------
+    pub_models : pd.DataFrame
+        Public models table.
+    event : gr.SelectData
+        Event containing the selected row.
+
+    Returns
+    -------
+    download_link : gr.Textbox
+        Autofilled download link.
+    model_name : gr.Textbox
+        Autofilled model name.
+    """
     event_index = event.index[0]
     url_str = pub_models.loc[event_index, "URL"]
     model_str = pub_models.loc[event_index, "Model Name"]
@@ -52,9 +110,28 @@ def render(
     dummy_deletion_checkbox: gr.Checkbox,
     delete_confirmation: gr.State,
     rvc_models_to_delete: gr.Dropdown,
-    rvc_model: gr.Dropdown,
-    rvc_model2: gr.Dropdown,
+    rvc_model_1click: gr.Dropdown,
+    rvc_model_multi: gr.Dropdown,
 ) -> None:
+    """
+    Render "Manage models" tab.
+
+    Parameters
+    ----------
+    dummy_deletion_checkbox : gr.Checkbox
+        Dummy component needed for deletion confirmation in the
+        "Manage audio" tab and the "Manage models" tab.
+    delete_confirmation : gr.State
+        Component storing deletion confirmation status in the
+        "Manage audio" tab and the "Manage models" tab.
+    rvc_models_to_delete : gr.Dropdown
+        Dropdown for selecting models to delete in the
+        "Manage models" tab.
+    rvc_model_1click : gr.Dropdown
+        Dropdown for selecting models in the "One-click generation" tab.
+    rvc_model_multi : gr.Dropdown
+        Dropdown for selecting models in the "Multi-step generation" tab.
+    """
 
     # Download tab
     with gr.Tab("Download model"):
@@ -214,6 +291,6 @@ def render(
     ]:
         click_event.success(
             partial(_update_model_lists, 3, [], [2]),
-            outputs=[rvc_model, rvc_model2, rvc_models_to_delete],
+            outputs=[rvc_model_1click, rvc_model_multi, rvc_models_to_delete],
             show_progress="hidden",
         )

--- a/src/init.py
+++ b/src/init.py
@@ -1,3 +1,7 @@
+"""
+This script downloads the models required for running the Ultimmate RVC app.
+"""
+
 import requests
 import os
 from common import RVC_MODELS_DIR
@@ -6,6 +10,18 @@ RVC_DOWNLOAD_LINK = "https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/
 
 
 def dl_model(link: str, model_name: str, dir_name: str) -> None:
+    """
+    Download a model from a link and save it to a directory.
+
+    Parameters
+    ----------
+    link : str
+        The link to the site where the model is hosted.
+    model_name : str
+        The name of the model to download.
+    dir_name : str
+        The directory to save the model to.
+    """
     with requests.get(f"{link}{model_name}") as r:
         r.raise_for_status()
         with open(os.path.join(dir_name, model_name), "wb") as f:

--- a/src/typings/extra.py
+++ b/src/typings/extra.py
@@ -14,8 +14,6 @@ DropdownValue = (
 
 InputType = Literal["yt", "local"]
 
-SongCoverNameUpdateKey = Literal["value", "placeholder"]
-
 F0Method = Literal["rmvpe", "mangio-crepe"]
 
 InputAudioExt = Literal["mp3", "wav", "flac", "aac", "m4a", "ogg"]


### PR DESCRIPTION
Adds docstrings to backend and frontend modules. In addition this PR also
* Adds a hash  size parameter to the `get_file_hash` function
* Updates some error messages thrown by functions from the backend. Now these error messages are more informative and appropriate
* refactors/simplifies the `filter_public_models_table` function
* Makes typing of `percentages` parameters be tuples and removes corresponding length checks
* Adds an extra check to the `_yt_download` helper function. This check raises an error when a youtube link is valid but does not lead to any content
* Fixes a bug where choosing "aac" as output format leads to "m4a" output format
* Reparametrizes the helper function `_mix_audio` so that it takes one parameter for each input audio file instead of a list containing all input audio files
* Reparametrizes `_mak_song_dir` so that its control flow is a bit more logical
* Refactors (and renames) `get_song_cover_name_harness` so that parameter `update_key` becomes `update_placeholder` which is a boolean indicating whether only the given textbox placeholder should be updated
* renames several other functions (and some variables) in both frontend and backend modules so they are consistent with docstring descriptions