### PR TITLE
Add pyproject config file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.analysis.stubPath": "src/typings",
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,104 @@
+[tool.pyright]
+stubPath = "src/typings"
+pythonVersion = "3.11"
+pythonPlatform = "All"
+typeCheckingMode = "strict"
+
+[tool.black]
+target-version = ['py311']
+preview = true
+enable-unstable-feature = ["string_processing"]
+
+[tool.ruff]
+extend-include = ["*.ipynb"]
+target-version = "py311"
+fix = true
+required-version = ">=0.5.7"
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = ["ALL"]
+extend-select = ["I"]
+ignore = ["D205", "D203", "D212", "D416"]
+unfixable = ["F401"]
+preview = true
+
+[tool.ruff.lint.flake8-annotations]
+ignore-fully-untyped = true
+#suppress-none-returning = true
+
+[tool.ruff.lint.flake8-errmsg]
+#max-string-length = 20
+
+[tool.ruff.lint.isort]
+relative-imports-order = "closest-to-furthest"
+section-order = [
+    "future",
+    "typing",
+    "standard-library",
+    "third-party",
+    "networking",
+    "data-science",
+    "machine-learning",
+    "audio",
+    "visualisation",
+    "first-party",
+    "vc",
+    "backend",
+    "frontend",
+    "base",
+    "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+"typing" = ["typing", "typing_extensions", "typings"]
+"networking" = [
+    "requests",
+    "yt_dlp",
+    "deemix",
+    "wget",
+    "flask",
+    "beautifulsoup4",
+    "pypresence",
+]
+"data-science" = ["numpy", "scipy", "matplotlib", "tqdm", "pandas", "gradio"]
+"machine-learning" = [
+    "torch",
+    "torchaudio",
+    "torchcrepe",
+    "fairseq",
+    "faiss",
+    "tensorboard",
+    "torchfcpe",
+    "local_attention",
+    "libf0",
+    "einops",
+    "numba",
+]
+"audio" = [
+    "ffmpeg",
+    "soundfile",
+    "librosa",
+    "sox",
+    "pydub",
+    "pedalboard",
+    "audio_separator",
+    "parselmouth",
+    "pyworld",
+    "noisereduce",
+    "audio_upscaler",
+    "edge_tts",
+    "ffmpy",
+]
+"vc" = ["vc"]
+"backend" = ["backend"]
+"frontend" = ["frontend"]
+"base" = ["common", "app", "cli", "init"]
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 72
+
+[tool.ruff.lint.pylint]
+# max-args = 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,58 +1,55 @@
-# General dependencies
-ffmpeg-python>=0.2.0
-numpy==1.23.5
-requests==2.32.3 #NOTE upgraded from 2.32.0
-tqdm==4.65.0 #NOTE upgraded from unspecified
-# TODO add these later
-# wget
+# General
+lib==4.0.0
 
-# Audio processing
-#faiss-cpu==1.7.3 # NOTE outcommented due to incompatibility on windows
-librosa >=0.10 # NOTE upgraded from 0.9.2
-pyworld==0.3.4
-scipy~=1.13.0 # NOTE upgraded from 1.11.1
-soundfile==0.12.1
-praat-parselmouth>=0.4.2 # NOTE upgraded from unspecified
-pedalboard==0.9.12
-pydub==0.25.1
-pydub-stubs
-sox==1.5.0
-audio-separator[gpu]==0.18.3
+# Networking
+requests==2.32.3 #NOTE upgraded from 2.32.0
+yt_dlp==2024.8.6
 #TODO add these later
-#noisereduce
-#audio_upscaler==0.1.4
-#deemix
+# deemix
+# wget
+# flask
+# beautifulsoup4
+# pypresence
+
+# Data science
+numpy==1.23.5
+scipy~=1.13.0 # NOTE upgraded from 1.11.1
+matplotlib==3.9.0 #NOTE upgraded from 3.7.2
+tqdm==4.65.0 #NOTE upgraded from unspecified
+gradio==4.42.0
 
 # Machine learning
-./dependencies/fairseq-0.12.2-cp311-cp311-linux_x86_64.whl; sys_platform == 'linux'
-./dependencies/fairseq-0.12.3.1-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
-./dependencies/diffq-0.2.4-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.1.1+cu121 # NOTE upgraded from 2.0.1+cu118
 torchaudio==2.1.1+cu121
 torchcrepe==0.0.23 # NOTE upgraded from 0.0.20
-#TODO add these later
-#numba; sys_platform == 'linux'
-#numba==0.57.0; sys_platform == 'darwin' or sys_platform == 'win32'
-#einops 
-#libf0 
-#torchfcpe
-
-# Visualization
-gradio==4.41.0
-matplotlib==3.9.0 #NOTE upgraded from 3.7.2
-#TODO add these later
-
-#tensorboard
-
-# Miscellaneous
-lib==4.0.0
-yt_dlp==2024.8.6
+./dependencies/fairseq-0.12.2-cp311-cp311-linux_x86_64.whl; sys_platform == 'linux'
+./dependencies/fairseq-0.12.3.1-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
+./dependencies/diffq-0.2.4-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
 tensorboardX
 #TODO add these later
-#ffmpy==0.3.1
-#edge-tts==6.1.9
-#pypresence
-#beautifulsoup4
-#flask
-#local-attention
+# faiss-cpu==1.7.3 # NOTE outcommented due to incompatibility on windows
+# tensorboard
+# torchfcpe
+# local-attention
+# libf0 
+# einops 
+# numba; sys_platform == 'linux'
+# numba==0.57.0; sys_platform == 'darwin' or sys_platform == 'win32'
+
+# Audio
+ffmpeg-python>=0.2.0
+soundfile==0.12.1
+librosa >=0.10 # NOTE upgraded from 0.9.2
+sox==1.5.0
+pydub==0.25.1
+pydub-stubs
+pedalboard==0.9.12
+audio-separator[gpu]==0.18.3
+praat-parselmouth>=0.4.2 # NOTE upgraded from unspecified
+pyworld==0.3.4
+#TODO add the later
+# noisereduce
+# audio_upscaler==0.1.4
+# edge-tts==6.1.9
+# ffmpy==0.3.1


### PR DESCRIPTION
Adds a `pyproject.toml` config file. For now, the file configures this project to use ruff for linting, pyright for type-checking and black for formatting. 

Additionally, this PR also re-organizes sections in `requirements.txt` and promotes the gradio package to version `4.42.0`