### PR TITLE
use queue for limiting gpu specific jobs

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -90,6 +90,11 @@
 
 * Split components under vocal conversion options into two rows
   * always show "hop length", "detection algorithm" and "protect rate" on second row
+* consider always showing intermediate audio tracks accordion.
+
+* Consider running one click generation as multiple events consecutively instead of one event, so that we can apply the gpu limit to just the steps that are actually using gpu
+  * With this solution we should probably save directly the output of the each step to its corresponding intermediate audio track
+  * An issue is that we might run into the bug with audio components not updating when using a chain of event listeners and having them update the intermediate audio tracks in turn.
 
 ### Common
 
@@ -101,10 +106,6 @@
   * Can output of js function be fed into python function in the same event listener definition?
   * If not possible then try to at least remove dummy input component and dummy/passthrough function in the confirmation event listener
   * See more info here: <https://github.com/gradio-app/gradio/issues/3324>
-* get rid of button blocking by setting `concurrency_id = "gpu"` + `concurrency_count=1` for reach event listener calling a function using the gpu
-  * Need to figure out which backend functions then actually use GPU
-  * In the future we might increase `concurrenct_count` when more GPUs become available
-  * NOTE: we still want to continue to block the checkbox for showing intermediate audio files while the one-click generation is running.
 * use `Block.queue` with parameter `max_size` set to a non-null value and `default_concurrency_limit` increased in order to improve user responsiveness
 * use `Block.launch()` with `max_file_size` to prevent too large uploads
 * experiment with `show_error` parameters on `Block.launch()`
@@ -506,6 +507,9 @@ case source_type:
   * See <https://www.gradio.app/guides/deploying-gradio-with-docker>
 * Host on own web-server with Nginx
   * see <https://www.gradio.app/guides/running-gradio-on-your-web-server-with-nginx>
+
+* Consider having concurrency limit be dynamic, i.e. instead of always being 1 for jobs using gpu consider having it depend upon what resources are available.
+  * We can app set the GPU_CONCURRENCY limit to be os.envrion["GPU_CONCURRENCY_LIMIT] or 1 and then pass GPU_CONCURRENCY as input to places where event listeners are defined
 
 ## Colab notebook
 

--- a/src/app.py
+++ b/src/app.py
@@ -111,25 +111,9 @@ with gr.Blocks(
     ]
     model_delete = gr.Dropdown(label="Voice models", multiselect=True, render=False)
 
-    generate_btns = [
-        gr.Button(label, variant="primary", render=False, scale=scale)
-        for label, scale, in [
-            ("Retrieve song", 1),
-            ("Separate vocals/instrumentals", 1),
-            ("Separate main/backup vocals", 1),
-            ("De-reverb vocals", 1),
-            ("Convert vocals", 1),
-            ("Post-process vocals", 1),
-            ("Pitch shift background", 1),
-            ("Mix song", 1),
-            ("Generate", 2),
-        ]
-    ]
-
     # main tab
     with gr.Tab("Generate song covers"):
         render_one_click_tab(
-            generate_btns,
             song_dirs,
             cached_song_1click,
             cached_song_multi,
@@ -138,7 +122,6 @@ with gr.Blocks(
             output_audio,
         )
         render_multi_step_tab(
-            generate_btns,
             song_dirs,
             cached_song_1click,
             cached_song_multi,

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -641,6 +641,8 @@ def init_song_dir(
         raise NotProvidedError(entity=Entity.SOURCE, ui_msg=UIMessage.NO_SOURCE)
     source_path = Path(source)
 
+    display_progress("[~] Initializing song directory...", percentage, progress_bar)
+
     # if source is a path to an existing song directory
     if source_path.is_dir():
         if source_path.parent != INTERMEDIATE_AUDIO_BASE_DIR:
@@ -656,8 +658,6 @@ def init_song_dir(
         )
         source_type = SourceType.SONG_DIR
         return source_path, source_type
-
-    display_progress("[~] Creating new song directory...", percentage, progress_bar)
 
     # if source is a URL
     if urlparse(source).scheme == "https":

--- a/src/backend/typing_extra.py
+++ b/src/backend/typing_extra.py
@@ -1,7 +1,7 @@
 """Module which defines extra types for the backend."""
 
 from collections.abc import Callable
-from enum import StrEnum
+from enum import StrEnum, auto
 
 from pydantic import BaseModel, ConfigDict
 
@@ -98,9 +98,9 @@ ModelMetaDataList = list[list[str | list[ModelTagName]]]
 class SourceType(StrEnum):
     """The type of source providing the song to generate a cover of."""
 
-    URL = "url"
-    FILE = "file"
-    SONG_DIR = "song_dir"
+    URL = auto()
+    FILE = auto()
+    SONG_DIR = auto()
 
 
 class AudioExtInternal(StrEnum):

--- a/src/frontend/typing_extra.py
+++ b/src/frontend/typing_extra.py
@@ -3,15 +3,19 @@
 from typing import Any, TypedDict
 
 from collections.abc import Callable, Sequence
-from enum import StrEnum
-
-from typing_extra import AudioExt, F0Method
+from enum import StrEnum, auto
 
 DropdownChoices = Sequence[str | int | float | tuple[str, str | int | float]] | None
 
 DropdownValue = (
     str | int | float | Sequence[str | int | float] | Callable[..., Any] | None
 )
+
+
+class ConcurrencyId(StrEnum):
+    """Enumeration of possible concurrency identifiers."""
+
+    GPU = auto()
 
 
 class SourceType(StrEnum):
@@ -85,28 +89,3 @@ class UpdateAudioKwArgs(TypedDict, total=False):
     """
 
     value: str | None
-
-
-RunPipelineHarnessArgs = tuple[
-    str,  # source
-    str,  # model_name
-    int,  # n_octaves
-    int,  # n_semitones
-    F0Method,  # f0_method
-    float,  # index_rate
-    int,  # filter_radius
-    float,  # rms_mix_rate
-    float,  # protect
-    int,  # hop_length
-    float,  # room_size
-    float,  # wet_level
-    float,  # dry_level
-    float,  # damping
-    int,  # main_gain
-    int,  # inst_gain
-    int,  # backup_gain
-    int,  # output_sr
-    AudioExt,  # output_format
-    str,  # output_name
-    bool,  # return_immediate
-]


### PR DESCRIPTION
This queue replaces the current method of blocking all "generate" buttons when a generation process is running with simply using gradio's queue system for queuing up any jobs that might use the GPU. Additionally, this PR also:
* gets rids of the `chain_event_listeners` helper function
* refactors `frontend.multi_step_generation` by defining all transfer events in one for-loop block and inlining button definitions
* Updates `frontend.one_click_generation` so that intermediate files are always returned and these are not deleted when toggling the "show intermediate audio" checkbox. 
* Removes blocking of the "show intermediate audio" checkbox during generation, as that is no longer a problem when all intermediate audio is always returned.
* updates enum definitions to use `auto` where it makes sense