### PR TITLE
add path validation functions

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -3,7 +3,7 @@
 * test that app works through notebook
 
 * should specify in colab notebook which link in output of last cell should be clicked
-
+* we should make str enum for vocal separation model names and perhaps also for audio stem names?
 * should rename instances of "models" to "voice models"
 
 * have some default models available (ie.e do not need to be downloaded)
@@ -171,13 +171,9 @@ case source_type:
 ...
 ```
 
-* Make helper function that both calls `AUDIO_SEPARATOR.separate` and moves its result(s) to the right folder
 * split `pitch_shift_background` into
   * one base function `pitch_shift`
   * and simple wrapper function `pitch_shift_background` that calls `pitch_shift`two times
-* refactor the three audio separation functions (`separate_vocals`,`separate_main_vocals` and `dereverb`) into
-  * One base function `separate_audio`
-  * Three wrapper functions (`separate_vocals`,`separate_main_vocals` and `dereverb`) that calls `pitch_shift` with simple parameters
 * Implement Pydantic models for the remaining steps in song cover generation pipeline and then instantiate arg dicts by doing `XMetaData.model_dump()`
   * Should we use `model_dump` with `mode = "json"`to ensure JSON-serializable dicts?
 * Support specific audio formats for intermediate audio file?

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -171,15 +171,6 @@ case source_type:
 ...
 ```
 
-* Use list comprehension to DRY code in cover pipeline functions
-  * Use "double-nested" list comprehension that first makes the necessary calls to `get_unique_base_path` in inner loop and then for each appends `'.wav'` and `'.json'` in outer loop.
-  * Apply `all` to result of previous list-comprehension to simplify file path checks
-* Make helper function for path validation
-  * signature is `validate(files, dirs)`
-  * both `files` and `dirs` should have types `list[StrPath]`
-  * should check that each item in `files` and `dirs`
-    * is not `None`
-    * either points to a valid existing file or directory
 * Make helper function that both calls `AUDIO_SEPARATOR.separate` and moves its result(s) to the right folder
 * split `pitch_shift_background` into
   * one base function `pitch_shift`
@@ -190,9 +181,7 @@ case source_type:
 * Implement Pydantic models for the remaining steps in song cover generation pipeline and then instantiate arg dicts by doing `XMetaData.model_dump()`
   * Should we use `model_dump` with `mode = "json"`to ensure JSON-serializable dicts?
 * Support specific audio formats for intermediate audio file?
-  * We might also want to disable gradio saving input audio to temporary files, as those are always in `.wav` format
-    * See more [here](#temporary-gradio-files)
-  * Also, it might require some more code to support custom output format for all pipeline functions.
+  * it might require some more code to support custom output format for all pipeline functions.
 
 * expand `_get_model_name` so that it can take any audio file in an intermediate audio folder as input (DIFFICULT TO IMPLEMENT)
   * Function should then try to recursively

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -171,9 +171,6 @@ case source_type:
 ...
 ```
 
-* split `pitch_shift_background` into
-  * one base function `pitch_shift`
-  * and simple wrapper function `pitch_shift_background` that calls `pitch_shift`two times
 * Implement Pydantic models for the remaining steps in song cover generation pipeline and then instantiate arg dicts by doing `XMetaData.model_dump()`
   * Should we use `model_dump` with `mode = "json"`to ensure JSON-serializable dicts?
 * Support specific audio formats for intermediate audio file?

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -160,17 +160,6 @@
 
 ### `generate_song_cover.py`
 
-* Use a case match expression in `retrieve_song`
-
-```python
-case source_type:
-    match SourceType.SONG_DIR
-        song_path = _get_input_audio_path(song_dir_path)
-    match SourceType.URL
-    ...
-...
-```
-
 * Implement Pydantic models for the remaining steps in song cover generation pipeline and then instantiate arg dicts by doing `XMetaData.model_dump()`
   * Should we use `model_dump` with `mode = "json"`to ensure JSON-serializable dicts?
 * Support specific audio formats for intermediate audio file?

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -153,15 +153,17 @@
 
 ## Back end
 
-### `common.py`
-
-* Define custom order for items in saved JSON files.
-  * Should be the same as the order of items defined in pydantic models?
-
 ### `generate_song_cover.py`
 
-* Implement Pydantic models for the remaining steps in song cover generation pipeline and then instantiate arg dicts by doing `XMetaData.model_dump()`
-  * Should we use `model_dump` with `mode = "json"`to ensure JSON-serializable dicts?
+* find framework for caching intermediate results rather than relying on your homemade system
+
+  * Joblib: <https://medium.com/@yuxuzi/unlocking-efficiency-in-machine-learning-projects-with-joblib-a-python-pipeline-powerhouse-feb0ebfdf4df>
+  * scikit learn: <https://scikit-learn.org/stable/modules/compose.html#pipeline>
+
+  * <https://softwarepatternslexicon.com/machine-learning/infrastructure-and-scalability/workflow-management/pipeline-caching/>
+  * <https://github.com/bmabey/provenance>
+  * <https://docs.sweep.dev/blogs/file-cache>
+
 * Support specific audio formats for intermediate audio file?
   * it might require some more code to support custom output format for all pipeline functions.
 

--- a/src/backend/common.py
+++ b/src/backend/common.py
@@ -108,13 +108,7 @@ def json_dumps(thing: Json) -> str:
         The JSON string representation of the object.
 
     """
-    return json.dumps(
-        thing,
-        ensure_ascii=False,
-        sort_keys=True,
-        indent=4,
-        separators=(",", ": "),
-    )
+    return json.dumps(thing, ensure_ascii=False, indent=4)
 
 
 def json_dump(thing: Json, file: StrPath) -> None:
@@ -130,14 +124,7 @@ def json_dump(thing: Json, file: StrPath) -> None:
 
     """
     with Path(file).open("w", encoding="utf-8") as fp:
-        json.dump(
-            thing,
-            fp,
-            ensure_ascii=False,
-            sort_keys=True,
-            indent=4,
-            separators=(",", ": "),
-        )
+        json.dump(thing, fp, ensure_ascii=False, indent=4)
 
 
 def json_load(file: StrPath, encoding: str = "utf-8") -> Json:

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -60,7 +60,11 @@ from backend.typing_extra import (
     ConvertedVocalsMetaData,
     EffectedVocalsMetaData,
     FileMetaData,
+    MixedSongMetaData,
+    PitchShiftMetaData,
+    SeparatedAudioMetaData,
     SourceType,
+    StereoizedAudioMetaData,
 )
 
 AUDIO_SEPARATOR = Separator(
@@ -863,9 +867,12 @@ def stereoize(
 
     song_info = pydub_utils.mediainfo(str(song_path))
     if song_info["channels"] == "1":
-        args_dict = {
-            "song": {"name": song_path.name, "hash_id": get_file_hash(song_path)},
-        }
+        args_dict = StereoizedAudioMetaData(
+            audio_track=FileMetaData(
+                name=song_path.name,
+                hash_id=get_file_hash(song_path),
+            ),
+        ).model_dump()
 
         paths = [
             get_unique_base_path(
@@ -996,12 +1003,14 @@ def separate_audio(
         [(audio_track, Entity.AUDIO_TRACK), (song_dir, Entity.SONG_DIR)],
     )
 
-    args_dict = {
-        "audio_track": {
-            "name": audio_path.name,
-            "hash_id": get_file_hash(audio_path),
-        },
-    }
+    args_dict = SeparatedAudioMetaData(
+        audio_track=FileMetaData(
+            name=audio_path.name,
+            hash_id=get_file_hash(audio_path),
+        ),
+        model_name=model_name,
+        segment_size=segment_size,
+    ).model_dump()
 
     paths = [
         get_unique_base_path(
@@ -1424,13 +1433,13 @@ def pitch_shift(
 
     if n_semitones != 0:
 
-        args_dict = {
-            "audio_track": {
-                "name": audio_path.name,
-                "hash_id": get_file_hash(audio_path),
-            },
-            "n_semitones": n_semitones,
-        }
+        args_dict = PitchShiftMetaData(
+            audio_track=FileMetaData(
+                name=audio_path.name,
+                hash_id=get_file_hash(audio_path),
+            ),
+            n_semitones=n_semitones,
+        ).model_dump()
 
         paths = [
             get_unique_base_path(
@@ -1629,25 +1638,25 @@ def mix_song_cover(
             ],
         )
     )
-    args_dict = {
-        "main_vocals_track": {
-            "name": main_vocals_path.name,
-            "hash_id": get_file_hash(main_vocals_path),
-        },
-        "instrumentals_track": {
-            "name": instrumentals_path.name,
-            "hash_id": get_file_hash(instrumentals_path),
-        },
-        "backup_vocals_track": {
-            "name": backup_vocals_path.name,
-            "hash_id": get_file_hash(backup_vocals_path),
-        },
-        "main_gain": main_gain,
-        "inst_gain": inst_gain,
-        "backup_gain": backup_gain,
-        "output_sr": output_sr,
-        "output_format": output_format,
-    }
+    args_dict = MixedSongMetaData(
+        main_vocals_track=FileMetaData(
+            name=main_vocals_path.name,
+            hash_id=get_file_hash(main_vocals_path),
+        ),
+        instrumentals_track=FileMetaData(
+            name=instrumentals_path.name,
+            hash_id=get_file_hash(instrumentals_path),
+        ),
+        backup_vocals_track=FileMetaData(
+            name=backup_vocals_path.name,
+            hash_id=get_file_hash(backup_vocals_path),
+        ),
+        main_gain=main_gain,
+        inst_gain=inst_gain,
+        backup_gain=backup_gain,
+        output_sr=output_sr,
+        output_format=output_format,
+    ).model_dump()
 
     paths = [
         get_unique_base_path(

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -924,27 +924,21 @@ def retrieve_song(
     ------
     NotProvidedError
         If no source is provided.
-    NotFoundError
-        if the source type is a song directory and no input audio file
-        is found in that directory.
 
     """
     if not source:
         raise NotProvidedError(entity=Entity.SOURCE, ui_msg=UIMessage.NO_SOURCE)
 
     song_dir_path, source_type = init_song_dir(source, progress_bar, percentage)
+    song_path = _get_input_audio_path(song_dir_path)
 
-    match source_type:
-        case SourceType.SONG_DIR:
-            song_path = _get_input_audio_path(song_dir_path)
-            if not song_path:
-                raise NotFoundError(Entity.SONG, "song directory")
-        case SourceType.URL:
+    if not song_path:
+        if source_type == SourceType.URL:
             display_progress("[~] Downloading song...", percentage, progress_bar)
             song_url = source.split("&")[0]
             song_path = _get_youtube_audio(song_url, song_dir_path)
 
-        case SourceType.FILE:
+        else:
             display_progress("[~] Copying song...", percentage, progress_bar)
             source_path = Path(source)
             song_name = f"0_{source_path.name}"

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -924,21 +924,27 @@ def retrieve_song(
     ------
     NotProvidedError
         If no source is provided.
+    NotFoundError
+        if the source type is a song directory and no input audio file
+        is found in that directory.
 
     """
     if not source:
         raise NotProvidedError(entity=Entity.SOURCE, ui_msg=UIMessage.NO_SOURCE)
 
     song_dir_path, source_type = init_song_dir(source, progress_bar, percentage)
-    song_path = _get_input_audio_path(song_dir_path)
 
-    if not song_path:
-        if source_type == SourceType.URL:
+    match source_type:
+        case SourceType.SONG_DIR:
+            song_path = _get_input_audio_path(song_dir_path)
+            if not song_path:
+                raise NotFoundError(Entity.SONG, "song directory")
+        case SourceType.URL:
             display_progress("[~] Downloading song...", percentage, progress_bar)
             song_url = source.split("&")[0]
             song_path = _get_youtube_audio(song_url, song_dir_path)
 
-        else:
+        case SourceType.FILE:
             display_progress("[~] Copying song...", percentage, progress_bar)
             source_path = Path(source)
             song_name = f"0_{source_path.name}"

--- a/src/backend/typing_extra.py
+++ b/src/backend/typing_extra.py
@@ -5,7 +5,7 @@ from enum import StrEnum, auto
 
 from pydantic import BaseModel, ConfigDict
 
-from typing_extra import F0Method
+from typing_extra import AudioExt, F0Method
 
 # Voice model management
 
@@ -131,6 +131,42 @@ class FileMetaData(BaseModel):
     hash_id: str
 
 
+class StereoizedAudioMetaData(BaseModel):
+    """
+    Metadata for a stereoized audio track.
+
+    Attributes
+    ----------
+    audio_track : FileMetaData
+        Metadata for the audio track that was stereoized.
+
+    """
+
+    audio_track: FileMetaData
+
+
+class SeparatedAudioMetaData(BaseModel):
+    """
+    Metadata for a separated audio track.
+
+    Attributes
+    ----------
+    audio_track : FileMetaData
+        Metadata for the audio track that was separated.
+    model_name : str
+        The name of the model used for separation.
+    segment_size : int
+        The segment size used for separation.
+
+    """
+
+    audio_track: FileMetaData
+    model_name: str
+    segment_size: int
+
+    model_config = ConfigDict(protected_namespaces=())
+
+
 class ConvertedVocalsMetaData(BaseModel):
     """
     Metadata for an RVC converted vocals track.
@@ -168,6 +204,7 @@ class ConvertedVocalsMetaData(BaseModel):
     rms_mix_rate: float
     protect: float
     hop_length: int
+
     model_config = ConfigDict(protected_namespaces=())
 
 
@@ -197,3 +234,55 @@ class EffectedVocalsMetaData(BaseModel):
     wet_level: float
     dry_level: float
     damping: float
+
+
+class PitchShiftMetaData(BaseModel):
+    """
+    Metadata for a pitch-shifted audio track.
+
+    Attributes
+    ----------
+    audio_track : FileMetaData
+        Metadata for the audio track that was pitch-shifted.
+    n_semitones : int
+        The number of semitones the audio track was pitch-shifted by.
+
+    """
+
+    audio_track: FileMetaData
+    n_semitones: int
+
+
+class MixedSongMetaData(BaseModel):
+    """
+    Metadata for a mixed song.
+
+    Attributes
+    ----------
+    main_vocals_track : FileMetaData
+        Metadata for the main vocals track that was mixed.
+    instrumentals_track : FileMetaData
+        Metadata for the instrumentals track that was mixed.
+    backup_vocals_track : FileMetaData
+        Metadata for the backup vocals track that was mixed.
+    main_gain : float
+        The gain applied to the main vocals track.
+    inst_gain : float
+        The gain applied to the instrumentals track.
+    backup_gain : float
+        The gain applied to the backup vocals track.
+    output_sr: int
+        The sample rate of the mixed song.
+    output_format: AudioExt
+        The audio format of the mixed song.
+
+    """
+
+    main_vocals_track: FileMetaData
+    instrumentals_track: FileMetaData
+    backup_vocals_track: FileMetaData
+    main_gain: float
+    inst_gain: float
+    backup_gain: float
+    output_sr: int
+    output_format: AudioExt

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -21,6 +21,7 @@ class Entity(StrEnum):
     MODEL_FILE = "model file"
     SOURCE = "source"
     SONG_DIR = "song directory"
+    AUDIO_TRACK = "audio track"
     SONG = "song"
     VOCALS_TRACK = "vocals track"
     INSTRUMENTALS_TRACK = "instrumentals track"


### PR DESCRIPTION
This PR refactors the backend (primarily `backend.generate_song_cover`) by
  * providing dedicated functions for validating that identifiers (names and paths) have been provided and that their associated entity (file, directory, audio track, voice model) exists on the file system. 
  * Used list comprehensions to dry code used for generating audio paths in most pipeline functions.
  * Drying the pipeline functions used for audio separation by having one main function and 3 wrapper functions calling that function.
  * Drying the pipeline function used for pitch shifting by having one main function and 2 wrappers that call that function
  * Added pydantic models for remaining pipeline functions and changed the format of saved json files so that the insertion order of keys in the exported dictionaries is preserved.