### PR TITLE
Major changes to multi-step generation

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -68,40 +68,40 @@
 
 ### Multi-step generation
 
-* Have reset and generate buttons side by side instead of vertically aligned
-* Have just one audio separation accordion
-* Have just one pitch shift accordion
-* Do not auto-transfer output tracks but instead have buttons that allow user to manually transfer output tracks when clicked
-* Split components under vocal conversion options into two rows
-  * always show "hop length", "detection algorithm" and "protect rate" on second row
-* consider making inputs section of each step accordion into a sub-accordion that is closed by default?
-* consider having buttons under the "convert vocals" accordion and the pitch shift accordion, which set the pitch shift semi-tones value in the other accordion to be equal to the current value in the current accordion.
+* have two inputs and corresponding pitch shift buttons in the pitch shift accordion step, i.e. one for pitch shifting instrumentals and one for pitch shifting instrumentals
+
+* add description describing how to use each accordion and and suggestions for workflows
 * If possible merge two consecutive event listeners using `update_cached_songs` in the song retrieval accordion.
-* optimize rendering of audio tracks in ui so that they load quickly (DIFFICULT TO IMPLEMENT)
-  * Problem seems to mainly affect step 1: song retrieval and step: 5 vocal post-processing
-    * In either case output tracks stop loading after some time
-    * `h11._util.LocalProtocolError: Too little data for declared Content-Length` is observed on command line
-  * Problem is gradio-specific and an issue has been raised [here](https://github.com/gradio-app/gradio/issues/8878)
+* add option for adding more input tracks to the mix song step
+  * new components should be created dynamically based on a textfield with names and a button for creating new component
+  * when creating a new component a new transfer button and dropdown should also be created
+  * and the transfer choices for all dropdowns should be updated to also include the new input track
+  * we need to consider how to want to handle vertical space
+    * should be we make a new row once more than 3 tracks are on one row?
+      * yes and there should be also created the new slider on a new row
+      * right under the first row (which itself is under the row with song dir dropdown)
+
+* should also have the possiblity to add more tracks to the pitch shift accordion.
+
+* add a confirmation box with warning if trying to transfer output track to input track that is not empty.
+  * could also have the possibility to ask the user to transfer to create a new input track and transfer the output track to it. 
+  * this would just be the same pop up confirmation box as before but in addition to yes and cancel options it will also have a "transfer to new input track" option. 
+  * we need custom javasctip for this.
+
 * Fix hashes of identical files being different for one-click and multi-step generation (DIFFICULT TO IMPLEMENT)
   * Seems to work except for when first running one click generation and then multi-step generation
-  * It is related to the bug mentioned above
-
-### Single step generation
-
-* Split components under vocal conversion options into two rows
-  * always show "hop length", "detection algorithm" and "protect rate" on second row
-* consider always showing intermediate audio tracks accordion.
-
-* Consider running one click generation as multiple events consecutively instead of one event, so that we can apply the gpu limit to just the steps that are actually using gpu
-  * With this solution we should probably save directly the output of the each step to its corresponding intermediate audio track
-  * An issue is that we might run into the bug with audio components not updating when using a chain of event listeners and having them update the intermediate audio tracks in turn.
+    * What happens is that when transferring an output track in multi-step generation the transferred output track is re-encoded (or possibly just re-saved) on disk which causes the hash to be different after transfering
+    * This happens only when transfering from the output of step 0 (song retrieval) and step 4 (vocal postprocessing)
+    * curiously, these steps were also the ones causing problems with loading output tracks before when we were auto transfering output tracks. 
+      * Hence the problem with hashing seems to be related to the gradio bug where loading into audio components does not work after a while when using too many consecutive event listeners.
+    * Also, it should be noted that transfering a manually uploaded file from step 0 does not result in reencoding (and hence a new hash)
+      * perhaps this is because a manually uplaoded audio file is already in the correct wav format while a downloaded song might be in a wrong wav format?
 
 ### Common
 
 * save default values for options for song generation in an `SongCoverOptionDefault` enum.
   * then reference this enum across the two tabs
   * and also use `list[SongCoverOptionDefault]` as input to reset settings click event listener in single click generation tab.
-* Do not pass dummy checkbox and confirmation state component but instead define them inline in `manage_audio` and `manage_models` frontend modules.
 * Try to merge event listeners for confirmation and action execution in `frontend.manage_audio` and `frontend.mange_models`
   * Can output of js function be fed into python function in the same event listener definition?
   * If not possible then try to at least remove dummy input component and dummy/passthrough function in the confirmation event listener

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,10 @@ tqdm==4.65.0 #NOTE upgraded from unspecified
 gradio==4.43.0
 
 # Machine learning
---find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.1.1+cu121 # NOTE upgraded from 2.0.1+cu118
-torchaudio==2.1.1+cu121
+--find-links https://download.pytorch.org/whl/torch/
+torch==2.4.1+cu121
+--find-links https://download.pytorch.org/whl/torchaudio/
+torchaudio==2.4.1+cu121
 torchcrepe==0.0.23 # NOTE upgraded from 0.0.20
 ./dependencies/fairseq-0.12.2-cp311-cp311-linux_x86_64.whl; sys_platform == 'linux'
 ./dependencies/fairseq-0.12.3.1-cp311-cp311-win_amd64.whl; sys_platform == 'win32'
@@ -46,7 +47,7 @@ sox==1.5.0
 pydub==0.25.1
 pydub-stubs==0.25.1.1
 pedalboard==0.9.12
-audio-separator[gpu]==0.18.3
+audio-separator[gpu]==0.21.1
 praat-parselmouth>=0.4.2 # NOTE upgraded from unspecified
 pyworld==0.3.4
 #TODO add the later

--- a/src/app.py
+++ b/src/app.py
@@ -62,9 +62,6 @@ with gr.Blocks(
 ) as app:
 
     gr.HTML("<h1>Ultimate RVC ❤️</h1>")
-
-    dummy_checkbox = gr.Checkbox(visible=False)
-    confirmation = gr.State(value=False)
     song_dirs = [
         gr.Dropdown(
             label="Song directory",
@@ -75,7 +72,7 @@ with gr.Blocks(
             ),
             render=False,
         )
-        for _ in range(7)
+        for _ in range(5)
     ]
     cached_song_1click, cached_song_multi = [
         gr.Dropdown(
@@ -131,8 +128,6 @@ with gr.Blocks(
         )
     with gr.Tab("Manage models"):
         render_manage_models_tab(
-            dummy_checkbox,
-            confirmation,
             model_delete,
             model_1click,
             model_multi,
@@ -140,8 +135,6 @@ with gr.Blocks(
     with gr.Tab("Manage audio"):
 
         render_manage_audio_tab(
-            dummy_checkbox,
-            confirmation,
             song_dirs,
             cached_song_1click,
             cached_song_multi,

--- a/src/backend/common.py
+++ b/src/backend/common.py
@@ -93,6 +93,39 @@ def copy_files_to_new_dir(files: Sequence[StrPath], directory: StrPath) -> None:
         shutil.copyfile(file_path, dir_path / file_path.name)
 
 
+def copy_file_safe(src: StrPath, dest: StrPath) -> Path:
+    """
+    Copy a file to a new location, appending a number if a file with the
+    same name already exists.
+
+    Parameters
+    ----------
+    src : strPath
+        The source file path.
+    dest : strPath
+        The candidate destination file path.
+
+    Returns
+    -------
+    Path
+        The final destination file path.
+
+    """
+    dest_path = Path(dest)
+    src_path = Path(src)
+    dest_dir = dest_path.parent
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_file = dest_path
+    counter = 1
+
+    while dest_file.exists():
+        dest_file = dest_dir / f"{dest_path.stem} ({counter}){src_path.suffix}"
+        counter += 1
+
+    shutil.copyfile(src, dest_file)
+    return dest_file
+
+
 def json_dumps(thing: Json) -> str:
     """
     Dump a JSON-serializable object to a JSON string.

--- a/src/backend/typing_extra.py
+++ b/src/backend/typing_extra.py
@@ -253,36 +253,39 @@ class PitchShiftMetaData(BaseModel):
     n_semitones: int
 
 
+class StagedAudioMetaData(BaseModel):
+    """
+    Metadata for a staged audio track.
+
+    Attributes
+    ----------
+    audio_track : FileMetaData
+        Metadata for the audio track that was staged.
+    gain : float
+        The gain applied to the audio track.
+
+    """
+
+    audio_track: FileMetaData
+    gain: float
+
+
 class MixedSongMetaData(BaseModel):
     """
     Metadata for a mixed song.
 
     Attributes
     ----------
-    main_vocals_track : FileMetaData
-        Metadata for the main vocals track that was mixed.
-    instrumentals_track : FileMetaData
-        Metadata for the instrumentals track that was mixed.
-    backup_vocals_track : FileMetaData
-        Metadata for the backup vocals track that was mixed.
-    main_gain : float
-        The gain applied to the main vocals track.
-    inst_gain : float
-        The gain applied to the instrumentals track.
-    backup_gain : float
-        The gain applied to the backup vocals track.
-    output_sr: int
+    staged_audio_tracks : list[StagedAudioMetaData]
+        Metadata for the staged audio tracks that were mixed.
+
+    output_sr : int
         The sample rate of the mixed song.
-    output_format: AudioExt
-        The audio format of the mixed song.
+    output_format : AudioExt
+        The audio file format of the mixed song.
 
     """
 
-    main_vocals_track: FileMetaData
-    instrumentals_track: FileMetaData
-    backup_vocals_track: FileMetaData
-    main_gain: float
-    inst_gain: float
-    backup_gain: float
+    staged_audio_tracks: list[StagedAudioMetaData]
     output_sr: int
     output_format: AudioExt

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -22,6 +22,7 @@ class Entity(StrEnum):
     SOURCE = "source"
     SONG_DIR = "song directory"
     AUDIO_TRACK = "audio track"
+    AUDIO_TRACK_GAIN_PAIRS = "pairs of audio track and gain"
     SONG = "song"
     VOCALS_TRACK = "vocals track"
     INSTRUMENTALS_TRACK = "instrumentals track"
@@ -43,6 +44,7 @@ class UIMessage(StrEnum):
     in place of backend exception messages.
     """
 
+    NO_AUDIO_TRACK = "No audio tracks provided."
     NO_SONG_DIR = "No song directory selected."
     NO_SONG_DIRS = (
         "No song directories selected. Please select one or more song directories"

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -11,7 +11,7 @@ import gradio as gr
 
 from exceptions import NotProvidedError
 
-from typing_extra import F0Method, P, T
+from typing_extra import P, T
 
 from backend.generate_song_cover import get_named_song_dirs, get_song_cover_name
 from backend.manage_audio import get_saved_output_audio
@@ -347,26 +347,6 @@ def toggle_visible_component(
             return gr.update(**update_args)
         case _:
             return tuple(gr.update(**update_args) for update_args in update_args_list)
-
-
-def show_hop_slider(f0_method: F0Method) -> gr.Slider:
-    """
-    Show or hide a slider component based on the provided pitch
-    detection method.
-
-    Parameters
-    ----------
-    f0_method : F0Method
-        Pitch detection algorithm to determine visibility of the
-        slider.
-
-    Returns
-    -------
-    gr.Slider
-        Slider component with visibility set accordingly.
-
-    """
-    return gr.Slider(visible=f0_method == F0Method.MANGIO_CREPE)
 
 
 def update_song_cover_name(

--- a/src/frontend/tabs/manage_audio.py
+++ b/src/frontend/tabs/manage_audio.py
@@ -25,8 +25,6 @@ from frontend.common import (
 
 
 def render(
-    dummy_checkbox: gr.Checkbox,
-    confirmation: gr.State,
     song_dirs: Sequence[gr.Dropdown],
     cached_song_1click: gr.Dropdown,
     cached_song_multi: gr.Dropdown,
@@ -38,12 +36,6 @@ def render(
 
     Parameters
     ----------
-    dummy_checkbox : gr.Checkbox
-        Dummy checkbox component needed for deletion confirmation in the
-        "Delete audio" tab and the "Manage models" tab.
-    confirmation : gr.State
-        Component storing deletion confirmation status in the
-        "Delete audio" tab and the "Manage models" tab.
     song_dirs : Sequence[gr.Dropdown]
         Dropdown components for selecting song directories in the
         "Multi-step generation" tab.
@@ -61,6 +53,8 @@ def render(
         "Delete audio" tab.
 
     """
+    dummy_checkbox = gr.Checkbox(visible=False)
+    confirmation = gr.State(value=False)
     with gr.Tab("Delete audio"):
         with gr.Accordion("Intermediate audio", open=False), gr.Row(equal_height=False):
             with gr.Column():

--- a/src/frontend/tabs/manage_models.py
+++ b/src/frontend/tabs/manage_models.py
@@ -136,8 +136,6 @@ def _autofill_model_name_and_url(
 
 
 def render(
-    dummy_checkbox: gr.Checkbox,
-    confirmation: gr.State,
     model_delete: gr.Dropdown,
     model_1click: gr.Dropdown,
     model_multi: gr.Dropdown,
@@ -148,12 +146,6 @@ def render(
 
     Parameters
     ----------
-    dummy_checkbox : gr.Checkbox
-        Dummy checkbox component needed for deletion confirmation in the
-        "Delete audio" tab and the "Delete models" tab.
-    confirmation : gr.State
-        Component storing deletion confirmation status in the
-        "Delete audio" tab and the "Delete models" tab.
     model_delete : gr.Dropdown
         Dropdown for selecting voice models to delete in the
         "Delete models" tab.
@@ -166,6 +158,9 @@ def render(
 
     """
     # Download tab
+
+    dummy_checkbox = gr.Checkbox(visible=False)
+    confirmation = gr.State(value=False)
     with gr.Tab("Download model"):
 
         with gr.Accordion("View public models table", open=False):

--- a/src/frontend/tabs/one_click_generation.py
+++ b/src/frontend/tabs/one_click_generation.py
@@ -12,7 +12,6 @@ from backend.generate_song_cover import run_pipeline
 from frontend.common import (
     PROGRESS_BAR,
     exception_harness,
-    show_hop_slider,
     toggle_visible_component,
     update_cached_songs,
     update_output_audio,
@@ -143,51 +142,52 @@ def render(
                     ),
                 )
 
-        with gr.Accordion("Vocal conversion options", open=False), gr.Row():
-            index_rate = gr.Slider(
-                0,
-                1,
-                value=0.5,
-                label="Index rate",
-                info=(
-                    "How much of the accent in the voice model to keep in the converted"
-                    " vocals. Increase to bias the conversion towards the accent of the"
-                    " voice model."
-                ),
-            )
-            filter_radius = gr.Slider(
-                0,
-                7,
-                value=3,
-                step=1,
-                label="Filter radius",
-                info=(
-                    "If >=3: apply median filtering to harvested pitch results."
-                    " Can help reduce breathiness in the converted vocals."
-                ),
-            )
-            rms_mix_rate = gr.Slider(
-                0,
-                1,
-                value=0.25,
-                label="RMS mix rate",
-                info=(
-                    "How much to mimic the loudness (0) of the input vocals or a fixed"
-                    " loudness (1)."
-                ),
-            )
-            protect = gr.Slider(
-                0,
-                0.5,
-                value=0.33,
-                label="Protect rate",
-                info=(
-                    "Protection of voiceless consonants and breath sounds. Decrease to"
-                    " increase protection at the cost of indexing accuracy. Set to 0.5"
-                    " to disable."
-                ),
-            )
-            with gr.Column():
+        with gr.Accordion("Vocal conversion options", open=False):
+            with gr.Row():
+                index_rate = gr.Slider(
+                    0,
+                    1,
+                    value=0.5,
+                    label="Index rate",
+                    info=(
+                        "How much of the accent in the voice model to keep in the"
+                        " converted vocals. Increase to bias the conversion towards the"
+                        " accent of the voice model."
+                    ),
+                )
+                filter_radius = gr.Slider(
+                    0,
+                    7,
+                    value=3,
+                    step=1,
+                    label="Filter radius",
+                    info=(
+                        "If >=3: apply median filtering to harvested pitch results."
+                        " Can help reduce breathiness in the converted vocals."
+                    ),
+                )
+                rms_mix_rate = gr.Slider(
+                    0,
+                    1,
+                    value=0.25,
+                    label="RMS mix rate",
+                    info=(
+                        "How much to mimic the loudness (0) of the input vocals or a"
+                        " fixed loudness (1)."
+                    ),
+                )
+            with gr.Row():
+                protect = gr.Slider(
+                    0,
+                    0.5,
+                    value=0.33,
+                    label="Protect rate",
+                    info=(
+                        "Protection of voiceless consonants and breath sounds. Decrease"
+                        " to increase protection at the cost of indexing accuracy. Set"
+                        " to 0.5 to disable."
+                    ),
+                )
                 f0_method = gr.Dropdown(
                     list(F0Method),
                     value=F0Method.RMVPE,
@@ -202,7 +202,6 @@ def render(
                     320,
                     value=128,
                     step=1,
-                    visible=False,
                     label="Hop length",
                     info=(
                         "How often the CREPE-based pitch detection algorithm checks for"
@@ -211,15 +210,9 @@ def render(
                         " but better pitch accuracy."
                     ),
                 )
-                f0_method.change(
-                    show_hop_slider,
-                    inputs=f0_method,
-                    outputs=hop_length,
-                    show_progress="hidden",
-                )
         with gr.Accordion("Audio mixing options", open=False):
             gr.Markdown("")
-            gr.Markdown("### Reverb control on converted vocals")
+            gr.Markdown("**Reverb control on converted vocals**")
             with gr.Row():
                 room_size = gr.Slider(
                     0,
@@ -231,6 +224,7 @@ def render(
                         " longer reverb time."
                     ),
                 )
+            with gr.Row():
                 wet_level = gr.Slider(
                     0,
                     1,
@@ -254,7 +248,7 @@ def render(
                 )
 
             gr.Markdown("")
-            gr.Markdown("### Volume controls (dB)")
+            gr.Markdown("**Volume controls (dB)**")
             with gr.Row():
                 main_gain = gr.Slider(-20, 20, value=0, step=1, label="Main vocals")
                 inst_gain = gr.Slider(-20, 20, value=0, step=1, label="Instrumentals")
@@ -301,12 +295,12 @@ def render(
             gr.Accordion(label, open=False, render=False)
             for label in [
                 "Step 0: song retrieval",
-                "Step 1: vocals/instrumentals separation",
-                "Step 2: main vocals/ backup vocals separation",
-                "Step 3: main vocals cleanup",
-                "Step 4: conversion of main vocals",
-                "Step 5: post-processing of converted vocals",
-                "Step 6: pitch shift of background tracks",
+                "Step 1a: vocals/instrumentals separation",
+                "Step 1b: main vocals/ backup vocals separation",
+                "Step 1c: main vocals cleanup",
+                "Step 2: conversion of main vocals",
+                "Step 3: post-processing of converted vocals",
+                "Step 4: pitch shift of background tracks",
             ]
         ]
         (

--- a/src/typing_extra.py
+++ b/src/typing_extra.py
@@ -17,6 +17,25 @@ StrPath = str | PathLike[str]
 Json = Mapping[str, "Json"] | Sequence["Json"] | str | int | float | bool | None
 
 
+class SeparationModel(StrEnum):
+    """The model to use for audio separation."""
+
+    UVR_MDX_NET_VOC_FT = "UVR-MDX-NET-Voc_FT.onnx"
+    UVR_MDX_NET_KARA_2 = "UVR_MDXNET_KARA_2.onnx"
+    REVERB_HQ_BY_FOXJOY = "Reverb_HQ_By_FoxJoy.onnx"
+
+
+class SegmentSize(IntEnum):
+    """The segment size to use for audio separation."""
+
+    SEG_64 = 64
+    SEG_128 = 128
+    SEG_256 = 256
+    SEG_512 = 512
+    SEG_1024 = 1024
+    SEG_2048 = 2048
+
+
 class F0Method(StrEnum):
     """The method to use for pitch detection."""
 


### PR DESCRIPTION
# Changelog

This PR makes major changes to the "Multi-step generation" tab, both on the frontend and backend side. A few other fixes and optimizations are made on the frontend side as well. The specific set of changes made by this PR is listed below.

## Package management

* promoted `audio-separator[gpu]` to version 0.21.1  and `torch` to version 2.4.1 to ensure compatibility with onnx-runtime.

## Backend

* Generalize `_mix_song`  and `mix_song` so that they take an arbitrary sequence of audio track and gain level pairs as input, rather than a fixed set of three audio tracks and three corresponding gain levels. This change includes:
  * Redefining the `StagedAudioMetaData` model so that it now has a `staged_audio_tracks` field which points to a list of one or `StagedAudioMetaData` models, each of which contain an `audio_track` field of type `FileMetaData` and a `gain` field.
  * Adding a new instance of `Entity` and `UiMessage`, which are used when raising an exception when the input list of audio track and gain level pairs is empty.
  * Adding a `display_msg` parameter to `mix_song` with an appropriate default value to control what message will be displayed when mixing audio tracks.
* Update `mix_song` so that existing output audio files are never overwritten by always checking whether a given song cover file name exist and in that case appending a number to distinguish the new file name from any existing file names.
* Add default values for the primary stem prefix and secondary stem prefix used by the `separate_audio` function.
* Remove the wrapper functions around `separate_audio` ( `separate_vocals`, `separate_main_vocals` , `dereverb`) and instead call `separate_audio` directly in the `run_pipeline` function.
* Remove the `pitch_shift_background` wrapper function and instead call `pitch_shift` directly in the `run_pipeline` function.

## Frontend

### General

* Define local "dummy" checkbox and "confirmation" state components directly in the "manage audio" and "manage models" tab contexts, rather than using globally defined equivalents.
* Split components associated with specific song cover generation steps over several rows to avoid cluttering. This includes:
  * Splitting the components associated with the "convert vocals" step over two rows, where the second row always shows the "hop length" slider component.

### Multi-step generation

* Replace the accordions for step 1-3 (vocal separation, main vocal separation and vocal cleanup) with one generic audio separation accordion that allows the user to supply a specific audio separation model and a corresponding segment size.
  * The idea is that the user can apply this step iteratively to achieve any kind of audio separation (including what was hardcoded before)
* Repurpose the accordion for pitch-shifting background tracks, so that it now has one button and pitch shift slider for each input, i.e. both for instrumentals and backup vocals.
* Replace automatic track transfering by manual transfering triggered when the user clicks a "Transfer" button under a given output track.
  * This changes is needed now that the control flow for multi-step generation can be more complicated.
  * Additionally, this change also prevents the bugs related to audio tracks not loading, which were observed before.
* Update the event listener on the "mix song" button, so that an arbitrary sequence of pairs of audio tracks and corresponding gain levels can be provided as input to the `mix_song` function.
  * This involves adding a pre-processing step where the set of audio tracks and corresponding gain levels defined in components in the "mix song" accordion are collected and paired using a `_pair_audio_tracks_and_gain` helper function.
  * This function also allows one or more audio tracks to be empty, as long as at least one provided audio track is not empty. The empty audio tracks and their corresponding gain levels are simply ignored.
  * This is needed now that we are giving the user the flexibility to not necessarily separate both backup vocals and instrumentals when using the multi-step generation pipeline.
* Update the `_update_audio` helper function with a new `disallow_none`, which when set (which is the default) prevents a component from having its value be updated to `None`. This is used to prevent input tracks accidentally being removed (replaced by `None`) when an empty output track is manually transferred.
* Add more markdown headers to separate sections inside accordions, namely headers for:
  * "Settings" containing inputs that do not need to be set but can customize output
  * "Controls" containing buttons that can be clicked
* move output track transfer dropdowns into "Settings" section (above their corresponding output tracks)
