### PR TITLE
Merge confirmation and action event listeners

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -68,8 +68,6 @@
 
 ### Multi-step generation
 
-* have two inputs and corresponding pitch shift buttons in the pitch shift accordion step, i.e. one for pitch shifting instrumentals and one for pitch shifting instrumentals
-
 * add description describing how to use each accordion and and suggestions for workflows
 * If possible merge two consecutive event listeners using `update_cached_songs` in the song retrieval accordion.
 * add option for adding more input tracks to the mix song step
@@ -102,10 +100,6 @@
 * save default values for options for song generation in an `SongCoverOptionDefault` enum.
   * then reference this enum across the two tabs
   * and also use `list[SongCoverOptionDefault]` as input to reset settings click event listener in single click generation tab.
-* Try to merge event listeners for confirmation and action execution in `frontend.manage_audio` and `frontend.mange_models`
-  * Can output of js function be fed into python function in the same event listener definition?
-  * If not possible then try to at least remove dummy input component and dummy/passthrough function in the confirmation event listener
-  * See more info here: <https://github.com/gradio-app/gradio/issues/3324>
 * use `Block.queue` with parameter `max_size` set to a non-null value and `default_concurrency_limit` increased in order to improve user responsiveness
 * use `Block.launch()` with `max_file_size` to prevent too large uploads
 * experiment with `show_error` parameters on `Block.launch()`

--- a/src/app.py
+++ b/src/app.py
@@ -38,7 +38,7 @@ def _init_app() -> list[gr.Dropdown]:
 
     """
     models = [gr.Dropdown(choices=get_saved_model_names()) for _ in range(3)]
-    cached_songs = [gr.Dropdown(choices=get_named_song_dirs()) for _ in range(10)]
+    cached_songs = [gr.Dropdown(choices=get_named_song_dirs()) for _ in range(8)]
     output_audio = [gr.Dropdown(choices=get_saved_output_audio())]
     return models + cached_songs + output_audio
 

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -120,39 +120,27 @@ def render_msg(
 
 def confirm_box_js(msg: str) -> str:
     """
-    Generate JavaScript code for a confirmation box.
+    Generate a JavaScript code snippet which:
+      * defines an anonymous function that takes one named parameter and
+      zero or more unnamed parameters
+      * renders a confirmation box
+      * returns the choice selected by the user in that confirmation
+      box in addition to any unnamed parameters passed to the function.
 
     Parameters
     ----------
     msg : str
-        Message to display in the confirmation box.
+        Message to display in the confirmation box rendered by the
+        JavaScript code snippet.
 
     Returns
     -------
     str
-        JavaScript code for the confirmation box.
+        The JavaScript code snippet.
 
     """
     formatted_msg = f"'{msg}'"
-    return f"(x) => confirm({formatted_msg})"
-
-
-def identity(x: T) -> T:
-    """
-    Identity function.
-
-    Parameters
-    ----------
-    x : T
-        Value to return.
-
-    Returns
-    -------
-    T
-        The value.
-
-    """
-    return x
+    return f"(x, ...args) => [confirm({formatted_msg}), ...args]"
 
 
 def update_value(x: str) -> dict[str, Any]:

--- a/src/frontend/tabs/manage_audio.py
+++ b/src/frontend/tabs/manage_audio.py
@@ -17,7 +17,6 @@ from frontend.common import (
     PROGRESS_BAR,
     confirm_box_js,
     confirmation_harness,
-    identity,
     render_msg,
     update_cached_songs,
     update_output_audio,
@@ -54,7 +53,6 @@ def render(
 
     """
     dummy_checkbox = gr.Checkbox(visible=False)
-    confirmation = gr.State(value=False)
     with gr.Tab("Delete audio"):
         with gr.Accordion("Intermediate audio", open=False), gr.Row(equal_height=False):
             with gr.Column():
@@ -92,136 +90,91 @@ def render(
             all_audio_btn = gr.Button("Delete", variant="primary")
             all_audio_msg = gr.Textbox(label="Output message", interactive=False)
 
-        intermediate_audio_click = (
-            intermediate_audio_btn.click(
-                identity,
-                inputs=dummy_checkbox,
-                outputs=confirmation,
-                js=confirm_box_js(
-                    "Are you sure you want to delete the selected song directories?",
-                ),
-                show_progress="hidden",
-            )
-            .then(
-                partial(
-                    confirmation_harness(delete_intermediate_audio),
-                    progress_bar=PROGRESS_BAR,
-                ),
-                inputs=[confirmation, intermediate_audio],
-                outputs=intermediate_audio_msg,
-            )
-            .success(
-                partial(
-                    render_msg,
-                    "[-] Successfully deleted the selected song directories!",
-                ),
-                outputs=intermediate_audio_msg,
-                show_progress="hidden",
-            )
+        intermediate_audio_click = intermediate_audio_btn.click(
+            partial(
+                confirmation_harness(delete_intermediate_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=[dummy_checkbox, intermediate_audio],
+            outputs=intermediate_audio_msg,
+            js=confirm_box_js(
+                "Are you sure you want to delete the selected song directories?",
+            ),
+        ).success(
+            partial(
+                render_msg,
+                "[-] Successfully deleted the selected song directories!",
+            ),
+            outputs=intermediate_audio_msg,
+            show_progress="hidden",
         )
 
-        all_intermediate_audio_click = (
-            all_intermediate_audio_btn.click(
-                identity,
-                inputs=dummy_checkbox,
-                outputs=confirmation,
-                js=confirm_box_js(
-                    "Are you sure you want to delete all intermediate audio files?",
-                ),
-                show_progress="hidden",
-            )
-            .then(
-                partial(
-                    confirmation_harness(delete_all_intermediate_audio),
-                    progress_bar=PROGRESS_BAR,
-                ),
-                inputs=confirmation,
-                outputs=intermediate_audio_msg,
-            )
-            .success(
-                partial(
-                    render_msg,
-                    "[-] Successfully deleted all intermediate audio files!",
-                ),
-                outputs=intermediate_audio_msg,
-                show_progress="hidden",
-            )
+        all_intermediate_audio_click = all_intermediate_audio_btn.click(
+            partial(
+                confirmation_harness(delete_all_intermediate_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=dummy_checkbox,
+            outputs=intermediate_audio_msg,
+            js=confirm_box_js(
+                "Are you sure you want to delete all intermediate audio files?",
+            ),
+        ).success(
+            partial(
+                render_msg,
+                "[-] Successfully deleted all intermediate audio files!",
+            ),
+            outputs=intermediate_audio_msg,
+            show_progress="hidden",
         )
 
-        output_audio_click = (
-            output_audio_btn.click(
-                identity,
-                inputs=dummy_checkbox,
-                outputs=confirmation,
-                js=confirm_box_js(
-                    "Are you sure you want to delete the selected output audio files?",
-                ),
-                show_progress="hidden",
-            )
-            .then(
-                partial(
-                    confirmation_harness(delete_output_audio),
-                    progress_bar=PROGRESS_BAR,
-                ),
-                inputs=[confirmation, output_audio],
-                outputs=output_audio_msg,
-            )
-            .success(
-                partial(
-                    render_msg,
-                    "[-] Successfully deleted the selected output audio files!",
-                ),
-                outputs=output_audio_msg,
-                show_progress="hidden",
-            )
+        output_audio_click = output_audio_btn.click(
+            partial(
+                confirmation_harness(delete_output_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=[dummy_checkbox, output_audio],
+            outputs=output_audio_msg,
+            js=confirm_box_js(
+                "Are you sure you want to delete the selected output audio files?",
+            ),
+        ).success(
+            partial(
+                render_msg,
+                "[-] Successfully deleted the selected output audio files!",
+            ),
+            outputs=output_audio_msg,
+            show_progress="hidden",
         )
 
-        all_output_audio_click = (
-            all_output_audio_btn.click(
-                identity,
-                inputs=dummy_checkbox,
-                outputs=confirmation,
-                js=confirm_box_js(
-                    "Are you sure you want to delete all output audio files?",
-                ),
-                show_progress="hidden",
-            )
-            .then(
-                partial(
-                    confirmation_harness(delete_all_output_audio),
-                    progress_bar=PROGRESS_BAR,
-                ),
-                inputs=confirmation,
-                outputs=output_audio_msg,
-            )
-            .success(
-                partial(render_msg, "[-] Successfully deleted all output audio files!"),
-                outputs=output_audio_msg,
-                show_progress="hidden",
-            )
+        all_output_audio_click = all_output_audio_btn.click(
+            partial(
+                confirmation_harness(delete_all_output_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=dummy_checkbox,
+            outputs=output_audio_msg,
+            js=confirm_box_js(
+                "Are you sure you want to delete all output audio files?",
+            ),
+        ).success(
+            partial(render_msg, "[-] Successfully deleted all output audio files!"),
+            outputs=output_audio_msg,
+            show_progress="hidden",
         )
 
-        all_audio_click = (
-            all_audio_btn.click(
-                identity,
-                inputs=dummy_checkbox,
-                outputs=confirmation,
-                js=confirm_box_js("Are you sure you want to delete all audio files?"),
-                show_progress="hidden",
-            )
-            .then(
-                partial(
-                    confirmation_harness(delete_all_audio),
-                    progress_bar=PROGRESS_BAR,
-                ),
-                inputs=confirmation,
-                outputs=all_audio_msg,
-            )
-            .success(
-                partial(render_msg, "[-] Successfully deleted all audio files!"),
-                outputs=all_audio_msg,
-                show_progress="hidden",
-            )
+        all_audio_click = all_audio_btn.click(
+            partial(
+                confirmation_harness(delete_all_audio),
+                progress_bar=PROGRESS_BAR,
+            ),
+            inputs=dummy_checkbox,
+            outputs=all_audio_msg,
+            js=confirm_box_js("Are you sure you want to delete all audio files?"),
+        ).success(
+            partial(render_msg, "[-] Successfully deleted all audio files!"),
+            outputs=all_audio_msg,
+            show_progress="hidden",
         )
 
         _, _, all_audio_update = [

--- a/src/frontend/tabs/other_settings.py
+++ b/src/frontend/tabs/other_settings.py
@@ -10,7 +10,6 @@ from frontend.common import (
     PROGRESS_BAR,
     confirm_box_js,
     confirmation_harness,
-    identity,
     render_msg,
 )
 
@@ -18,7 +17,6 @@ from frontend.common import (
 def render() -> None:
     """Render "Other settings" tab."""
     dummy_checkbox = gr.Checkbox(visible=False)
-    confirmation = gr.State(value=False)
 
     gr.Markdown("")
     with gr.Accordion("Temporary files", open=True):
@@ -28,22 +26,17 @@ def render() -> None:
             temporary_files_msg = gr.Textbox(label="Output message", interactive=False)
 
     temporary_files_btn.click(
-        identity,
+        partial(
+            confirmation_harness(delete_temp_files),
+            progress_bar=PROGRESS_BAR,
+        ),
         inputs=dummy_checkbox,
-        outputs=confirmation,
+        outputs=temporary_files_msg,
         js=confirm_box_js(
             "Are you sure you want to delete all temporary files? Any files uploaded"
             " directly via the UI will not be available for further processing until"
             " they are re-uploaded.",
         ),
-        show_progress="hidden",
-    ).then(
-        partial(
-            confirmation_harness(delete_temp_files),
-            progress_bar=PROGRESS_BAR,
-        ),
-        inputs=confirmation,
-        outputs=temporary_files_msg,
     ).success(
         partial(
             render_msg,


### PR DESCRIPTION
Until now we have had separate consecutive event listeners for storing deletion confirmation and acting on that confirmation if it has been given. This PR merges those sets of consecutive event listeners into one event listener. 

Additionally, this PR also fixes a bug where the dropdown with output audio files to delete is accidentally set to the set of intermediate audio directories when refreshing the browser window