### PR TITLE
Show info-box on generation completion

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -1,9 +1,6 @@
 # TODO
 
-* test that app works through notebook
-
 * should specify in colab notebook which link in output of last cell should be clicked
-* we should make str enum for vocal separation model names and perhaps also for audio stem names?
 * should rename instances of "models" to "voice models"
 
 * have some default models available (ie.e do not need to be downloaded)
@@ -103,10 +100,6 @@
 * use `Block.queue` with parameter `max_size` set to a non-null value and `default_concurrency_limit` increased in order to improve user responsiveness
 * use `Block.launch()` with `max_file_size` to prevent too large uploads
 * experiment with `show_error` parameters on `Block.launch()`
-* have pop-up success after any kind of job is done ?
-  * We can use `gr.Info` for this
-  * We already have a helper function `frontend.common.render_msg` which could be used for this purpose (after some small tweaks)
-  * In this case we could also consider removing output message textbox components in the `manage_models` and `manage_audio` tabs
 * Persist state of app (currently selected settings etc.) across re-renders
   * This includes:
     * refreshing a browser windows

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -27,7 +27,10 @@ from frontend.typing_extra import (
 PROGRESS_BAR = gr.Progress()
 
 
-def exception_harness(fn: Callable[P, T]) -> Callable[P, T]:
+def exception_harness(
+    fn: Callable[P, T],
+    info_msg: str | None = None,
+) -> Callable[P, T]:
     """
     Wrap a function in a harness that catches exceptions and re-raises
     them as instances of `gradio.Error`.
@@ -36,6 +39,10 @@ def exception_harness(fn: Callable[P, T]) -> Callable[P, T]:
     ----------
     fn : Callable[P, T]
         The function to wrap.
+
+    info_msg : str, optional
+        Message to display in an info-box pop-up after the function
+        executes successfully.
 
     Returns
     -------
@@ -46,7 +53,7 @@ def exception_harness(fn: Callable[P, T]) -> Callable[P, T]:
 
     def _wrapped_fn(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
-            return fn(*args, **kwargs)
+            res = fn(*args, **kwargs)
         except gr.Error:
             raise
         except NotProvidedError as e:
@@ -54,6 +61,10 @@ def exception_harness(fn: Callable[P, T]) -> Callable[P, T]:
             raise gr.Error(str(msg)) from None
         except Exception as e:
             raise gr.Error(str(e)) from e
+        else:
+            if info_msg:
+                gr.Info(info_msg, duration=2)
+            return res
 
     return _wrapped_fn
 

--- a/src/frontend/tabs/multi_step_generation.py
+++ b/src/frontend/tabs/multi_step_generation.py
@@ -345,7 +345,10 @@ def render(
             )
             retrieve_song_btn.click(
                 partial(
-                    exception_harness(retrieve_song),
+                    exception_harness(
+                        retrieve_song,
+                        info_msg="Song retrieved successfully!",
+                    ),
                     progress_bar=PROGRESS_BAR,
                 ),
                 inputs=source,
@@ -419,7 +422,10 @@ def render(
             )
             separate_vocals_btn.click(
                 partial(
-                    exception_harness(separate_audio),
+                    exception_harness(
+                        separate_audio,
+                        info_msg="Vocals separated successfully!",
+                    ),
                     progress_bar=PROGRESS_BAR,
                 ),
                 inputs=[
@@ -567,7 +573,10 @@ def render(
             )
             convert_vocals_btn.click(
                 partial(
-                    exception_harness(convert),
+                    exception_harness(
+                        convert,
+                        info_msg="Vocals converted successfully!",
+                    ),
                     progress_bar=PROGRESS_BAR,
                 ),
                 inputs=[
@@ -658,7 +667,10 @@ def render(
             )
             postprocess_vocals_btn.click(
                 partial(
-                    exception_harness(postprocess),
+                    exception_harness(
+                        postprocess,
+                        info_msg="Vocals post-processed successfully!",
+                    ),
                     progress_bar=PROGRESS_BAR,
                 ),
                 inputs=[
@@ -740,7 +752,10 @@ def render(
             )
             pitch_shift_instrumentals_btn.click(
                 partial(
-                    exception_harness(pitch_shift),
+                    exception_harness(
+                        pitch_shift,
+                        info_msg="Instrumentals pitch-shifted successfully!",
+                    ),
                     progress_bar=PROGRESS_BAR,
                     display_msg="Pitch shifting instrumentals...",
                 ),
@@ -753,7 +768,10 @@ def render(
             )
             pitch_shift_backup_vocals_btn.click(
                 partial(
-                    exception_harness(pitch_shift),
+                    exception_harness(
+                        pitch_shift,
+                        info_msg="Backup vocals pitch-shifted successfully!",
+                    ),
                     progress_bar=PROGRESS_BAR,
                     display_msg="Pitch shifting backup vocals...",
                 ),
@@ -869,7 +887,13 @@ def render(
                 },
                 outputs=temp_audio_gains,
             ).then(
-                partial(exception_harness(mix_song), progress_bar=PROGRESS_BAR),
+                partial(
+                    exception_harness(
+                        mix_song,
+                        info_msg="Song cover succesfully generated.",
+                    ),
+                    progress_bar=PROGRESS_BAR,
+                ),
                 inputs=[
                     temp_audio_gains,
                     mix_dir,

--- a/src/frontend/tabs/one_click_generation.py
+++ b/src/frontend/tabs/one_click_generation.py
@@ -389,7 +389,10 @@ def render(
 
         generate_btn.click(
             partial(
-                exception_harness(run_pipeline),
+                exception_harness(
+                    run_pipeline,
+                    info_msg="Song cover generated successfully!",
+                ),
                 return_intermediate=True,
                 progress_bar=PROGRESS_BAR,
             ),


### PR DESCRIPTION
This PR updates the front-end so that an info-box is shown whenever a generation step in either the "one-click generation" tab or the "multi-step generation" succesfully finishes. 