### PR TITLE
utilize new python 3.12 features

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -6,7 +6,6 @@
 * have some default models available (ie.e do not need to be downloaded)
   * should be downloaded as part of init.py
   * if one specific model exists this should be selected by default in all dropdowns (could be taylor swift)
-* update code to utilize new features from python 3.12
 * organize src as a package and always import as src.module.submodule
 
 ## Project/task management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,22 @@
 [tool.pyright]
 stubPath = "src/stubs"
-pythonVersion = "3.11"
+pythonVersion = "3.12"
 pythonPlatform = "All"
 typeCheckingMode = "strict"
 ignore = ["**/.venv"]
 
 [tool.black]
-target-version = ['py311']
+target-version = ['py312']
 preview = true
 enable-unstable-feature = ["string_processing"]
 
 [tool.ruff]
-extend-include = ["*.ipynb"]
-target-version = "py311"
+target-version = "py312"
 fix = true
 required-version = ">=0.5.7"
 
 [tool.ruff.format]
 docstring-code-format = true
-skip-magic-trailing-comma = true
 preview = true
 
 [tool.ruff.lint]

--- a/src/app.py
+++ b/src/app.py
@@ -67,7 +67,6 @@ def _render_app() -> gr.Blocks:
         css=css,
         delete_cache=(cache_delete_frequency, cache_delete_cutoff),
     ) as app:
-
         gr.HTML("<h1>Ultimate RVC ❤️</h1>")
         song_dirs = [
             gr.Dropdown(
@@ -140,7 +139,6 @@ def _render_app() -> gr.Blocks:
                 model_multi,
             )
         with gr.Tab("Manage audio"):
-
             render_manage_audio_tab(
                 song_dirs,
                 cached_song_1click,

--- a/src/backend/generate_song_cover.py
+++ b/src/backend/generate_song_cover.py
@@ -1021,7 +1021,6 @@ def separate_audio(
     ) = paths
 
     if not all(path.exists() for path in paths):
-
         display_progress(display_msg, percentage, progress_bar)
         AUDIO_SEPARATOR.arch_specific_params["MDX"]["segment_size"] = segment_size
         AUDIO_SEPARATOR.load_model(model_name)
@@ -1279,7 +1278,6 @@ def pitch_shift(
     shifted_audio_path = audio_path
 
     if n_semitones != 0:
-
         args_dict = PitchShiftMetaData(
             audio_track=FileMetaData(
                 name=audio_path.name,

--- a/src/backend/manage_models.py
+++ b/src/backend/manage_models.py
@@ -1,6 +1,5 @@
 """Module which defines functions to manage voice models."""
 
-import os
 import re
 import shutil
 import urllib.request
@@ -157,7 +156,7 @@ def filter_public_models_table(
         return (
             query.lower()
             in (
-                f"{model.name} {model.description} {' '.join(model.tags)} "
+                f"{model.name} {model.description} {" ".join(model.tags)} "
                 f"{model.credit} {model.added}"
             ).lower()
             if query
@@ -207,7 +206,7 @@ def _extract_model(
             zip_ref.extractall(extraction_path)
         file_path_map = {
             ext: Path(root, name)
-            for root, _, files in os.walk(extraction_path)
+            for root, _, files in extraction_path.walk()
             for name in files
             for ext in [".index", ".pth"]
             if Path(name).suffix == ext

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -293,5 +293,5 @@ class UploadFormatError(ValueError):
         suffix = "by themselves" if not multiple else "together (at most one of each)"
         super().__init__(
             f"Only {entity} with the following formats can be uploaded {suffix}:"
-            f" {', '.join(formats)}.",
+            f" {", ".join(formats)}.",
         )

--- a/src/frontend/common.py
+++ b/src/frontend/common.py
@@ -11,8 +11,6 @@ import gradio as gr
 
 from exceptions import NotProvidedError
 
-from typing_extra import P, T
-
 from backend.generate_song_cover import get_named_song_dirs, get_song_cover_name
 from backend.manage_audio import get_saved_output_audio
 
@@ -27,7 +25,7 @@ from frontend.typing_extra import (
 PROGRESS_BAR = gr.Progress()
 
 
-def exception_harness(
+def exception_harness[T, **P](
     fn: Callable[P, T],
     info_msg: str | None = None,
 ) -> Callable[P, T]:
@@ -69,7 +67,9 @@ def exception_harness(
     return _wrapped_fn
 
 
-def confirmation_harness(fn: Callable[P, T]) -> Callable[Concatenate[bool, P], T]:
+def confirmation_harness[T, **P](
+    fn: Callable[P, T],
+) -> Callable[Concatenate[bool, P], T]:
     """
     Wrap a function in a harness that requires a confirmation before
     executing and catches exceptions, re-raising them as instances of
@@ -150,8 +150,7 @@ def confirm_box_js(msg: str) -> str:
         The JavaScript code snippet.
 
     """
-    formatted_msg = f"'{msg}'"
-    return f"(x, ...args) => [confirm({formatted_msg}), ...args]"
+    return f"(x, ...args) => [confirm('{msg}'), ...args]"
 
 
 def update_value(x: str) -> dict[str, Any]:
@@ -172,7 +171,7 @@ def update_value(x: str) -> dict[str, Any]:
     return gr.update(value=x)
 
 
-def update_dropdowns(
+def update_dropdowns[**P](
     fn: Callable[P, DropdownChoices],
     num_components: int,
     value: DropdownValue = None,

--- a/src/frontend/tabs/manage_models.py
+++ b/src/frontend/tabs/manage_models.py
@@ -160,9 +160,7 @@ def render(
 
     dummy_checkbox = gr.Checkbox(visible=False)
     with gr.Tab("Download model"):
-
         with gr.Accordion("View public models table", open=False):
-
             gr.Markdown("")
             gr.Markdown("*HOW TO USE*")
             gr.Markdown(

--- a/src/frontend/tabs/one_click_generation.py
+++ b/src/frontend/tabs/one_click_generation.py
@@ -76,7 +76,6 @@ def render(
 
     """
     with gr.Tab("One-click generation"):
-
         with gr.Accordion("Main options"), gr.Row():
             with gr.Column():
                 source_type = gr.Dropdown(

--- a/src/frontend/typing_extra.py
+++ b/src/frontend/typing_extra.py
@@ -5,9 +5,11 @@ from typing import Any, TypedDict
 from collections.abc import Callable, Sequence
 from enum import StrEnum, auto
 
-DropdownChoices = Sequence[str | int | float | tuple[str, str | int | float]] | None
+type DropdownChoices = (
+    Sequence[str | int | float | tuple[str, str | int | float]] | None
+)
 
-DropdownValue = (
+type DropdownValue = (
     str | int | float | Sequence[str | int | float] | Callable[..., Any] | None
 )
 

--- a/src/init.py
+++ b/src/init.py
@@ -38,7 +38,6 @@ def download_model(url: str, name: str, directory: StrPath) -> None:
 
 
 if __name__ == "__main__":
-
     model_names = ["hubert_base.pt", "rmvpe.pt"]
     for model_name in model_names:
         rprint(f"Downloading {model_name}...")

--- a/src/stubs/soundfile/__init__.pyi
+++ b/src/stubs/soundfile/__init__.pyi
@@ -1,11 +1,11 @@
-from typing import Literal, TypeAlias
+from typing import Literal
 
 from os import PathLike
 
 import numpy as np
 from numpy.typing import NDArray
 
-DEFAULT_NDARRAY: TypeAlias = NDArray[np.float64 | np.float32 | np.int32 | np.int16]
+type DEFAULT_NDARRAY = NDArray[np.float64 | np.float32 | np.int32 | np.int16]
 
 def read(
     file: int | str | PathLike[str] | PathLike[bytes],

--- a/src/typing_extra.py
+++ b/src/typing_extra.py
@@ -1,20 +1,12 @@
 """Extra typing for backend and frontend."""
 
-from typing import ParamSpec, TypeVar
-
 from collections.abc import Mapping, Sequence
 from enum import IntEnum, StrEnum
 from os import PathLike
 
-P = ParamSpec("P")
-T = TypeVar("T")
-K = TypeVar("K")
-V = TypeVar("V")
+type StrPath = str | PathLike[str]
 
-
-StrPath = str | PathLike[str]
-
-Json = Mapping[str, "Json"] | Sequence["Json"] | str | int | float | bool | None
+type Json = Mapping[str, Json] | Sequence[Json] | str | int | float | bool | None
 
 
 class SeparationModel(StrEnum):


### PR DESCRIPTION
This PR updates the project by utilizing some new features introduced in python 3.1.2:
* use `Pathlib.walk` instead of `os.walk`
* use `type` notation for type variables
* use new inlined notation for generic type annotations

Additionally this pr updates `pyproject.toml` so that python version points to 3.12 and ruff formatting does not skip magic trailing commas. 