### PR TITLE
fix logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ The `ultimate-rvc` package exposes two commands:
 
 For more information on either command supply the option `--help`.
 
+### Environment Variables
+
+The behaviour of the Ultimate RVC package can be customized via a number of environment variables. Currently these environment variables control only logging behaviour. They are as follows:
+
+* `URVC_CONSOLE_LOG_LEVEL`: The log level for console logging. If not set, defaults to `ERROR`.
+* `URVC_FILE_LOG_LEVEL`: The log level for file logging. If not set, defaults to `INFO`.
+* `URVC_LOGS_DIR`: The directory in which log files will be stored. If not set, logs will be stored in a `logs` directory in the current working directory.
+* `URVC_NO_LOGGING`: If set to `1`, logging will be disabled.
+
 ## Terms of Use
 
 The use of the converted voice for the following purposes is prohibited.

--- a/notebooks/ultimate_rvc_colab.ipynb
+++ b/notebooks/ultimate_rvc_colab.ipynb
@@ -26,6 +26,7 @@
     "import codecs\n",
     "import threading\n",
     "import time\n",
+    "import os\n",
     "\n",
     "from IPython.display import clear_output\n",
     "\n",
@@ -88,12 +89,12 @@
     "# @title 2: Install dependencies\n",
     "\n",
     "light = codecs.decode(\"uggcf://nfgeny.fu/hi/0.5.0/vafgnyy.fu\", \"rot_13\")\n",
-    "\n",
     "inits = codecs.decode(\"./fep/hygvzngr_eip/pber/znva.cl\", \"rot_13\")\n",
     "\n",
     "!apt install -y python3-dev unzip\n",
-    "\n",
     "!curl -LsSf $light | sh\n",
+    "\n",
+    "os.environ[\"URVC_CONSOLE_LOG_LEVEL\"] = \"WARNING\"\n",
     "!uv run -q $inits\n",
     "clear_output()"
    ]

--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -1,17 +1,41 @@
 # TODO
 
+* need to make project version (in `pyproject.toml`) dynamic so that it is updated automatically when a new release is made
 * should specify in colab notebook which link in output of last cell should be clicked
+* start logging in modules from the ultimate_rvc project
+  * might not need to log in every module but start doing it for relevant operations such as
+    * when catching errors
+    * when significant events happen
+
 * should rename instances of "models" to "voice models"
 
 * upgrade gradio to version 5
 * use pyinstaller to install app into executable that also includes sox and ffmpeg as dependencies (DLLs)
-  * for now we can also use static_ffmpeg package to include ffmpeg in python without having to have it downloaded explicitly
 
 * make note about having to possibly do refresh (f5) when using colab to make default models appear
   * should also try to fix this
 * make note about audio component resetting sometimes when hitting press play
   * should also try to fix this
-  * might be related some error messages on the terminal with broken communication?
+  * might be related some error messages on the terminal with broken communication:
+  
+    ``` console
+    2024-11-11 21:02:34 | ERROR | asyncio | Exception in callback _ProactorBasePipeTransport._call_connection_lost(None)
+    handle: <Handle _ProactorBasePipeTransport._call_connection_lost(None)>
+    Traceback (most recent call last):
+      File "C:\Users\Jacki\AppData\Local\Programs\Python\Python312\Lib\asyncio\events.py", line 88, in _run
+        self._context.run(self._callback, *self._args)
+      File "C:\Users\Jacki\AppData\Local\Programs\Python\Python312\Lib\asyncio\proactor_events.py", line 165, in _call_connection_lost
+        self._sock.shutdown(socket.SHUT_RDWR)
+    ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host
+    2024-11-11 21:02:35 | ERROR | asyncio | Exception in callback _ProactorBasePipeTransport._call_connection_lost(None)
+    handle: <Handle _ProactorBasePipeTransport._call_connection_lost(None)>
+    Traceback (most recent call last):
+      File "C:\Users\Jacki\AppData\Local\Programs\Python\Python312\Lib\asyncio\events.py", line 88, in _run
+        self._context.run(self._callback, *self._args)
+      File "C:\Users\Jacki\AppData\Local\Programs\Python\Python312\Lib\asyncio\proactor_events.py", line 165, in _call_connection_lost
+        self._sock.shutdown(socket.SHUT_RDWR)
+    ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host
+    ```
 
 * update stubs
 
@@ -97,15 +121,15 @@
 * should also have the possiblity to add more tracks to the pitch shift accordion.
 
 * add a confirmation box with warning if trying to transfer output track to input track that is not empty.
-  * could also have the possibility to ask the user to transfer to create a new input track and transfer the output track to it. 
-  * this would just be the same pop up confirmation box as before but in addition to yes and cancel options it will also have a "transfer to new input track" option. 
+  * could also have the possibility to ask the user to transfer to create a new input track and transfer the output track to it.
+  * this would just be the same pop up confirmation box as before but in addition to yes and cancel options it will also have a "transfer to new input track" option.
   * we need custom javasctip for this.
 
 * Fix hashes of identical files being different for one-click and multi-step generation (DIFFICULT TO IMPLEMENT)
   * Seems to work except for when first running one click generation and then multi-step generation
     * What happens is that when transferring an output track in multi-step generation the transferred output track is re-encoded (or possibly just re-saved) on disk which causes the hash to be different after transfering
     * This happens only when transfering from the output of step 0 (song retrieval) and step 4 (vocal postprocessing)
-    * curiously, these steps were also the ones causing problems with loading output tracks before when we were auto transfering output tracks. 
+    * curiously, these steps were also the ones causing problems with loading output tracks before when we were auto transfering output tracks.
       * Hence the problem with hashing seems to be related to the gradio bug where loading into audio components does not work after a while when using too many consecutive event listeners.
     * Also, it should be noted that transfering a manually uploaded file from step 0 does not result in reencoding (and hence a new hash)
       * perhaps this is because a manually uplaoded audio file is already in the correct wav format while a downloaded song might be in a wrong wav format?
@@ -188,14 +212,6 @@
 
 ## CLI
 
-* consider making all calls to library functions be quiet (not print anything) by default
-* consider also printing status messages to terminal when running webapp (not just cli)
-
-### Update `display_progress` function
-
-* Always log information message using standard python logging facilities
-* rename to `log_progress`?
-
 ### Potentially implement audio conversion
 
 * When using CLI input files might not be .wave format. This is a problem because
@@ -214,14 +230,6 @@
 * Interface for `core.manage_models`
 * Interface for `core.manage_audio`
 * Interfaces for individual pipeline functions defined in `core.generate_song_covers`
-* Interface for `core.main`, meaning setup/initialization of project
-  * could also consider compiling cli package with those dependencies so that we dont need to support this kind of initialization
-  * need to look into uv and hatch for this
-
-### Support making CLI into redistributable package (served on PyPI)
-
-* fix current errors which maybe due to the current project structure
-  * name of folder for cli library is not ultimate-rvc
 
 ## python package management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ultimate-rvc"
-version = "0.1.22"
+version = "0.1.23"
 description = "Ultimate RVC"
 readme = "README.md"
 requires-python = "==3.12.*"

--- a/src/ultimate_rvc/__init__.py
+++ b/src/ultimate_rvc/__init__.py
@@ -1,1 +1,41 @@
 """The Ultimate RVC project."""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from ultimate_rvc.common import BASE_DIR
+
+logger = logging.getLogger()
+
+URVC_NO_LOGGING = os.getenv("URVC_NO_LOGGING", "0") == "1"
+URVC_LOGS_DIR = Path(os.getenv("URVC_LOGS_DIR") or BASE_DIR / "logs")
+URVC_CONSOLE_LOG_LEVEL = os.getenv("URVC_CONSOLE_LOG_LEVEL", "ERROR")
+URVC_FILE_LOG_LEVEL = os.getenv("URVC_FILE_LOG_LEVEL", "INFO")
+
+if URVC_NO_LOGGING:
+    logging.basicConfig(handlers=[logging.NullHandler()])
+
+else:
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(URVC_CONSOLE_LOG_LEVEL)
+
+    URVC_LOGS_DIR.mkdir(exist_ok=True, parents=True)
+    file_handler = RotatingFileHandler(
+        URVC_LOGS_DIR / "ultimate_rvc.log",
+        mode="a",
+        maxBytes=1024 * 1024 * 5,
+        backupCount=1,
+        encoding="utf-8",
+    )
+    file_handler.setLevel(URVC_FILE_LOG_LEVEL)
+
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        style = "%",
+        level=logging.INFO,
+        handlers=[stream_handler, file_handler],
+    )
+

--- a/src/ultimate_rvc/core/common.py
+++ b/src/ultimate_rvc/core/common.py
@@ -29,8 +29,8 @@ def display_progress(
     progress_bar: gr.Progress | None = None,
 ) -> None:
     """
-    Display progress message and percentage in console or Gradio
-    progress bar.
+    Display progress message and percentage in console and potentially
+    also Gradio progress bar.
 
     Parameters
     ----------
@@ -42,9 +42,8 @@ def display_progress(
         The Gradio progress bar to update.
 
     """
-    if progress_bar is None:
-        rprint(message)
-    else:
+    rprint(message)
+    if progress_bar is not None:
         progress_bar(percentage, desc=message)
 
 

--- a/src/ultimate_rvc/core/main.py
+++ b/src/ultimate_rvc/core/main.py
@@ -40,7 +40,6 @@ def initialize() -> None:
     download_base_models()
     download_sample_models()
     initialize_audio_separator()
-    rprint("Initialization complete.")
 
 
 if __name__ == "__main__":

--- a/src/ultimate_rvc/vc/infer_pack/models.py
+++ b/src/ultimate_rvc/vc/infer_pack/models.py
@@ -611,7 +611,7 @@ class SynthesizerTrnMs256NSFsid(nn.Module):
             inter_channels, hidden_channels, 5, 1, 3, gin_channels=gin_channels
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()
@@ -722,7 +722,7 @@ class SynthesizerTrnMs768NSFsid(nn.Module):
             inter_channels, hidden_channels, 5, 1, 3, gin_channels=gin_channels
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()
@@ -830,7 +830,7 @@ class SynthesizerTrnMs256NSFsid_nono(nn.Module):
             inter_channels, hidden_channels, 5, 1, 3, gin_channels=gin_channels
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()
@@ -932,7 +932,7 @@ class SynthesizerTrnMs768NSFsid_nono(nn.Module):
             inter_channels, hidden_channels, 5, 1, 3, gin_channels=gin_channels
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()

--- a/src/ultimate_rvc/vc/infer_pack/models_onnx.py
+++ b/src/ultimate_rvc/vc/infer_pack/models_onnx.py
@@ -623,7 +623,7 @@ class SynthesizerTrnMsNSFsidM(nn.Module):
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
         self.speaker_map = None
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()

--- a/src/ultimate_rvc/vc/infer_pack/models_onnx_moess.py
+++ b/src/ultimate_rvc/vc/infer_pack/models_onnx_moess.py
@@ -609,7 +609,7 @@ class SynthesizerTrnMs256NSFsidM(nn.Module):
             inter_channels, hidden_channels, 5, 1, 3, gin_channels=gin_channels
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()
@@ -697,7 +697,7 @@ class SynthesizerTrnMs256NSFsid_sim(nn.Module):
             inter_channels, hidden_channels, 5, 1, 3, gin_channels=gin_channels
         )
         self.emb_g = nn.Embedding(self.spk_embed_dim, gin_channels)
-        print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
+        # print("gin_channels:", gin_channels, "self.spk_embed_dim:", self.spk_embed_dim)
 
     def remove_weight_norm(self):
         self.dec.remove_weight_norm()


### PR DESCRIPTION
# CHANGELOG

This pr reduces the excessive console logging that is coming from third party packages (libraries) and at the same time adds support for more verbose file logging. It does not by manually configuring the root logger of   the ultimate-rvc package using ``logging.BasicConfig` (in the __init__.py file of the project). The logging has been made configurable via environment variables. The environment variables are:

* `URVC_CONSOLE_LOG_LEVEL`: The log level for console logging. If not set, defaults to `ERROR`.
* `URVC_FILE_LOG_LEVEL`: The log level for file logging. If not set, defaults to `INFO`.
* `URVC_LOGS_DIR`: The directory in which log files will be stored. If not set, logs will be stored in a `logs` directory in the current working directory.
* `URVC_NO_LOGGING`: If set to `1`, logging will be disabled.

Additionally, this PR also:

* makes `print_progress` always print to console in addition to potentially updating a gradio progress bar
* outcomments "debug" print statements in modules from the `ultimate_rvc.vc` package.
* Sets console logging level for colab notebook to `WARNING`.
* Adds information on logging environment variables to `README.md`.
* Publishes a new version of the ultimte-rvc package.