### PR TITLE
Optimize CLI startup time

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -1,9 +1,10 @@
 # TODO
 
 * should rename instances of "models" to "voice models"
-
-* remove old vc folder
-* format rvc package folder
+* make subsections under accorditions under one click generation tab into sub accordions ?
+  * applies for voice conversion options and audio mixing options
+* fix problem with audio components restarting if play button is pressed too fast after loading new audio
+  * this is a gradio bug so report?
 
 ## Project/task management
 
@@ -181,10 +182,6 @@
 
 ### general
 
-
-* shave off more startup time
-  * get static ffmpeg to load only when needed
-  * in cli only load from the generate song cover module when needed (lazily)
 * look into typer replacement like cyclopts
   * so that we dont have to define separate cli wrappers for each function
   * just need to make sure that cyclopts can also do some of the automatic input validation that typer does

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ultimate-rvc"
-version = "0.1.26"
+version = "0.2.0"
 description = "Ultimate RVC"
 readme = "README.md"
 requires-python = "==3.12.*"
@@ -20,7 +20,7 @@ dependencies = [
     
     # Networking
     "requests==2.32.3",
-    "yt_dlp==2024.11.4",
+    "yt_dlp==2024.12.6",
     "nodejs-wheel-binaries==22.11.0",
     "wget",
     # TODO potentially add these later

--- a/src/ultimate_rvc/cli/generate/tts.py
+++ b/src/ultimate_rvc/cli/generate/tts.py
@@ -5,12 +5,9 @@ TTS.
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
-import asyncio
 import time
-
-from edge_tts import list_voices as _list_voices
 
 import typer
 from rich import print as rprint
@@ -18,7 +15,18 @@ from rich.panel import Panel
 from rich.table import Table
 
 from ultimate_rvc.cli.common import format_duration
-from ultimate_rvc.core.generate.tts import run_edge_tts as _run_edge_tts
+from ultimate_rvc.common import lazy_import
+
+if TYPE_CHECKING:
+    import asyncio
+
+    import edge_tts
+
+    from ultimate_rvc.core.generate import tts as generate_tts
+else:
+    asyncio = lazy_import("asyncio")
+    edge_tts = lazy_import("edge_tts")
+    generate_tts = lazy_import("ultimate_rvc.core.generate.tts")
 
 app = typer.Typer(
     name="tts",
@@ -80,7 +88,7 @@ def run_edge_tts(
     rprint("[~] Converting text to speech using Edge TTS...")
 
     audio_path = asyncio.run(
-        _run_edge_tts(
+        generate_tts.run_edge_tts(
             source,
             voice,
             pitch_shift,
@@ -151,7 +159,7 @@ def list_voices(
     """List all available edge TTS voices."""
     start_time = time.perf_counter()
     rprint("[~] Retrieving information on all available edge TTS voices...")
-    voices = asyncio.run(_list_voices())
+    voices = asyncio.run(edge_tts.list_voices())
     keys = [
         "Name",
         "FriendlyName",

--- a/src/ultimate_rvc/common.py
+++ b/src/ultimate_rvc/common.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import importlib.util
 import os
+import sys
 from pathlib import Path
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 BASE_DIR = Path.cwd()
 MODELS_DIR = Path(os.getenv("URVC_MODELS_DIR") or BASE_DIR / "models")
@@ -14,3 +21,41 @@ VOICE_MODELS_DIR = Path(
 SEPARATOR_MODELS_DIR = MODELS_DIR / "audio_separator"
 AUDIO_DIR = Path(os.getenv("URVC_AUDIO_DIR") or BASE_DIR / "audio")
 TEMP_DIR = Path(os.getenv("URVC_TEMP_DIR") or BASE_DIR / "temp")
+
+
+def lazy_import(name: str) -> ModuleType:
+    """
+    Lazy import a module.
+
+    Parameters
+    ----------
+    name : str
+        The name of the module to import.
+
+    Returns
+    -------
+    ModuleType
+        The imported module.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If the module is not found.
+    ImportError
+        If the loader is not found for the module.
+
+    """
+    spec = importlib.util.find_spec(name)
+    if spec is None:
+        msg = f"module {name!r} not found"
+        raise ModuleNotFoundError(msg)
+    if spec.loader is None:
+        msg = f"loader not found for module {name!r}"
+        raise ImportError(msg)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+
+    return module

--- a/src/ultimate_rvc/core/generate/__init__.py
+++ b/src/ultimate_rvc/core/generate/__init__.py
@@ -2,11 +2,3 @@
 Package which defines modules that facilitate RVC based audio
 generation.
 """
-
-from __future__ import annotations
-
-import static_ffmpeg
-import static_sox
-
-static_ffmpeg.add_paths()
-static_sox.add_paths()

--- a/src/ultimate_rvc/core/generate/tts.py
+++ b/src/ultimate_rvc/core/generate/tts.py
@@ -11,8 +11,7 @@ from pathlib import Path
 
 import anyio
 
-from edge_tts import Communicate
-
+from ultimate_rvc.common import lazy_import
 from ultimate_rvc.core.common import (
     TTS_AUDIO_BASE_DIR,
     display_progress,
@@ -30,6 +29,11 @@ from ultimate_rvc.core.typing_extra import (
 
 if TYPE_CHECKING:
     import gradio as gr
+
+    import edge_tts
+
+else:
+    edge_tts = lazy_import("edge_tts")
 
 
 async def run_edge_tts(
@@ -122,7 +126,7 @@ async def run_edge_tts(
         speed_change_str = f"{speed_change:+}%"
         volume_change_str = f"{volume_change:+}%"
 
-        communicate = Communicate(
+        communicate = edge_tts.Communicate(
             text,
             voice,
             pitch=pitch_shift_str,

--- a/src/ultimate_rvc/rvc/__init__.py
+++ b/src/ultimate_rvc/rvc/__init__.py
@@ -2,21 +2,3 @@
 The rvc package is a collection of tools for voice cloning using the RVC
 method.
 """
-
-from __future__ import annotations
-
-import static_ffmpeg
-
-from ultimate_rvc.rvc.lib.tools.prerequisites_download import (
-    prequisites_download_pipeline,
-)
-
-prequisites_download_pipeline(
-    pretraineds_v1_f0=False,
-    pretraineds_v1_nof0=False,
-    pretraineds_v2_f0=False,
-    pretraineds_v2_nof0=False,
-    models=True,
-    exe=False,
-)
-static_ffmpeg.add_paths()

--- a/src/ultimate_rvc/rvc/infer/pipeline.py
+++ b/src/ultimate_rvc/rvc/infer/pipeline.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import gc
 import os
 import re
@@ -9,7 +11,6 @@ from scipy import signal
 import faiss
 import torch
 import torch.nn.functional as F
-import torchcrepe
 from torch import Tensor
 
 import librosa
@@ -19,9 +20,14 @@ sys.path.append(now_dir)
 
 import logging
 
-from ultimate_rvc.common import RVC_MODELS_DIR
+from ultimate_rvc.common import RVC_MODELS_DIR, lazy_import
 from ultimate_rvc.rvc.lib.predictors.FCPE import FCPEF0Predictor
 from ultimate_rvc.rvc.lib.predictors.RMVPE import RMVPE0Predictor
+
+if TYPE_CHECKING:
+    import torchcrepe
+else:
+    torchcrepe = lazy_import("torchcrepe")
 
 # logging.getLogger("faiss").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)

--- a/src/ultimate_rvc/rvc/lib/tools/prerequisites_download.py
+++ b/src/ultimate_rvc/rvc/lib/tools/prerequisites_download.py
@@ -1,11 +1,19 @@
+from typing import TYPE_CHECKING
+
 import os
 from concurrent.futures import ThreadPoolExecutor
 
-import requests
+from ultimate_rvc.common import RVC_MODELS_DIR, lazy_import
 
-from tqdm import tqdm
+if TYPE_CHECKING:
+    import requests
 
-from ultimate_rvc.common import RVC_MODELS_DIR
+    import tqdm
+
+else:
+    requests = lazy_import("requests")
+    tqdm = lazy_import("tqdm")
+
 
 url_base = "https://huggingface.co/IAHispano/Applio/resolve/main/Resources"
 
@@ -199,7 +207,7 @@ def prequisites_download_pipeline(
     )
 
     if total_size > 0:
-        with tqdm(
+        with tqdm.tqdm(
             total=total_size,
             unit="iB",
             unit_scale=True,

--- a/src/ultimate_rvc/rvc/lib/utils.py
+++ b/src/ultimate_rvc/rvc/lib/utils.py
@@ -16,8 +16,8 @@ from transformers import HubertModel
 
 import librosa
 import soundfile as sf
-from pydub import AudioSegment
 
+# from pydub import AudioSegment
 from ultimate_rvc.common import RVC_MODELS_DIR
 
 # Remove this to see warnings about transformers models

--- a/src/ultimate_rvc/web/main.py
+++ b/src/ultimate_rvc/web/main.py
@@ -13,6 +13,11 @@ from typing import Annotated
 
 import os
 
+# NOTE this import is lazily imported later in another module. It is
+# imported here as well to avoid user warnings due to imcompatiblity
+# with gradio.
+import yt_dlp  # type: ignore[ReportUnusedImport] # noqa: F401
+
 import gradio as gr
 
 import typer

--- a/src/ultimate_rvc/web/tabs/manage_models.py
+++ b/src/ultimate_rvc/web/tabs/manage_models.py
@@ -9,10 +9,7 @@ from functools import partial
 
 import gradio as gr
 
-# NOTE gradio is using pandas under the hood so it must be
-# imported at runtime.
-import pandas as pd  # noqa: TC002
-
+from ultimate_rvc.common import lazy_import
 from ultimate_rvc.core.manage.models import (
     delete_all_models,
     delete_models,
@@ -33,7 +30,12 @@ from ultimate_rvc.web.common import (
 
 if TYPE_CHECKING:
 
+    import pandas as pd
+
     from ultimate_rvc.web.typing_extra import DropdownValue
+
+else:
+    pd = lazy_import("pandas")
 
 
 def _update_models(


### PR DESCRIPTION
This PR shaves off CLI startup time by lazily-importing heavy packages, primarily those imported by `ultimate_rvc.core.generate.song_cover` . Additionally, this PR also

* updates `yt-dlp` to the latest version
* removes import of `static_ffmpg` package upon initialization of the `ultimate_rvc.rvc` package as ffmpeg does not seem to be needed for rvc inference.
* removes import and use of `prequisites_download_pipeline` upon initialization of `ultimate_rvc.rvc` package as that
should be done by a calling script
* comments out import of `pydub` in `ultimate_rvc.rvc` package, as it is not used.
* converts more print statement in `ultimate_rvc.rvc.infer.infer` to `INFO` level logging statements.