### PR TITLE
Fix reload mode bugs

### DIFF
--- a/notes/TODO.md
+++ b/notes/TODO.md
@@ -1,8 +1,4 @@
 # TODO
-
-* fix problem with vocal conversion becoming slow after running multiple times
-* fix typing of gradio app.load function
-  * make pr for gradio fixing it
   
 ## Project/task management
 
@@ -93,25 +89,10 @@
 ### Common
 
 * redesign/simplify ui using new side-bar component from gradio
-* simplify and extend progress bar functionality by using the new show_progress_on and show_progress paramters on event listeners (https://github.com/gradio-app/gradio/pull/10492)
-* optimize rendering speed using new js=True parameter (https://github.com/gradio-app/gradio/pull/10500)
 * optimize rendering colab notebook
 
 * fix problem with audio components restarting if play button is pressed too fast after loading new audio
   * this is a gradio bug so report?
-* fix new problem with hot reload:
-
-  ```python
-  Reloading src.ultimate_rvc.web.main failed with the following exception: 
-  Traceback (most recent call last):
-    File "C:\Users\Jacki\repositories\ultimate-rvc\uv\.venv\Lib\site-packages\gradio\utils.py", line 302, in watchfn
-      changed_module = _find_module(changed)
-                      ^^^^^^^^^^^^^^^^^^^^^
-    File "C:\Users\Jacki\repositories\ultimate-rvc\uv\.venv\Lib\site-packages\gradio\utils.py", line 226, in _find_module
-      for s, v in sys.modules.items():
-                  ^^^^^^^^^^^^^^^^^^^
-  RuntimeError: dictionary changed size during iteration
-  ```
 
 * it is possible to have several parallel event listeners for a component:
   * like if we have click_event = some_component.click(...) then we can have several click.then event listeners.
@@ -141,6 +122,9 @@
     * Whenever the state of a component is changed save the new state to a custom JSON file.
       * Then whenever the app is refreshed load the current state of components from the JSON file
       * This solution should probably work for Block types that are not components
+
+* fix problem with reload mode not working for indirectly referenced files (DIFFICULT TO IMPLEMENT)
+  * this is a gradio bug so report?
 * fix gradio problem where last field components on a row are not aligned (DIFFICULT TO IMPLEMENT)
   * current solution with manual `<br>` padding is way too hacky.
   * this is a gradio bug so report?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "scipy==1.15.2",
     "matplotlib==3.10.1",
     "tqdm==4.67.1",
-    "gradio==5.20.0",
+    "gradio==5.22.0",
     
     # Machine learning
     "torch==2.6.0+cu124",

--- a/src/ultimate_rvc/core/main.py
+++ b/src/ultimate_rvc/core/main.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pathlib import Path
-
 import lazy_loader as lazy
+
+from pathlib import Path
 
 from rich import print as rprint
 

--- a/src/ultimate_rvc/web/tabs/manage/models.py
+++ b/src/ultimate_rvc/web/tabs/manage/models.py
@@ -30,6 +30,7 @@ from ultimate_rvc.core.manage.models import (
     get_public_model_tags,
     get_training_model_names,
     get_voice_model_names,
+    load_public_models_table,
     upload_custom_embedder_model,
     upload_voice_model,
 )
@@ -241,8 +242,7 @@ def render(
                     )
                 with gr.Row():
                     public_models_table = gr.Dataframe(
-                        value=_filter_public_models_table,
-                        inputs=[tags, search_query],
+                        value=load_public_models_table([]),
                         headers=[
                             "Name",
                             "Description",
@@ -254,6 +254,17 @@ def render(
                         label="Public models table",
                         interactive=False,
                     )
+                # We are updating the table here instead of doing it
+                # implicitly using value=_filter_public_models_table
+                # and inputs=[tags, search_query] when instantiating
+                # gr.Dataframe because that does not work with reload
+                # mode due to a bug.
+                gr.on(
+                    triggers=[search_query.change, tags.change],
+                    fn=_filter_public_models_table,
+                    inputs=[tags, search_query],
+                    outputs=public_models_table,
+                )
 
             with gr.Row():
                 voice_model_url = gr.Textbox(


### PR DESCRIPTION
Fixes bug where reload mode does not work due to the public models table being updated implicitly by initialising the `gr.Dataframe` instance with `value = some function` and `inputs = function inputs`.  The new solution is to instead explicitly update the public models table using the `gr.on` event listener