### PR TITLE
Promote PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd ultimate-rvc
 ./urvc install 
 ```
 
-Note that on Linux, this command will install the CUDA 12.5 toolkit system-wide, if it is not already available. In case you have problems, you may need to install the toolkit manually.
+Note that on Linux, this command will install the CUDA 12.8 toolkit system-wide, if it is not already available. In case you have problems, you may need to install the toolkit manually.
 
 ### Start the app
 
@@ -126,10 +126,10 @@ The Ultimate RVC project is also available as a [distributable package](https://
 
 ### Installation
 
-The package can be installed with pip in a **Python 3.12**-based environment. To do so requires first installing PyTorch with Cuda support:
+The package can be installed with pip in a **Python 3.12**-based environment. To do so requires first installing PyTorch with CUDA support:
 
 ```console
-pip install torch==2.6.0+cu124 torchaudio==2.6.0+cu124 --index-url https://download.pytorch.org/whl/cu124
+pip install torch==2.7.0+cu128 torchaudio==2.7.0+cu128 --index-url https://download.pytorch.org/whl/cu128
 ```
 
 The Ultimate RVC project package can then be installed as follows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ultimate-rvc"
-version = "0.5.5"
+version = "0.5.6"
 description = "Ultimate RVC"
 readme = "README.md"
 requires-python = "==3.12.*"
@@ -66,8 +66,8 @@ dependencies = [
 
 [project.optional-dependencies]
 cuda = [
-    "torch==2.6.0+cu124",
-    "torchaudio==2.6.0+cu124",
+    "torch==2.7.0+cu128",
+    "torchaudio==2.7.0+cu128",
 ]
 rocm = [
     "torch==2.6.0+rocm6.2.4 ; sys_platform == 'linux'",
@@ -92,19 +92,19 @@ conflicts = [
 [tool.uv.sources]
 torch = [
     { index = "torch-rocm",  extra = "rocm"},
-    { index = "torch-cu124", extra = "cuda"},
+    { index = "torch-cu128", extra = "cuda"},
     ]
 torchaudio = [
     { index = "torch-rocm",  extra = "rocm"},
-    { index = "torch-cu124", extra = "cuda"},
+    { index = "torch-cu128", extra = "cuda"},
     ] 
 pytorch-triton-rocm = [
     { index = "torch-rocm",  extra = "rocm"},
     ]
 
 [[tool.uv.index]]
-name = "torch-cu124"
-url = "https://download.pytorch.org/whl/cu124"
+name = "torch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 [[tool.uv.index]]
 name = "torch-rocm"

--- a/src/ultimate_rvc/web/tabs/generate/speech/one_click_generation.py
+++ b/src/ultimate_rvc/web/tabs/generate/speech/one_click_generation.py
@@ -56,7 +56,7 @@ def render(total_config: TotalConfig) -> None:
         with gr.Row(equal_height=True):
             reset_btn = gr.Button(value="Reeset settings", scale=2)
             generate_btn = gr.Button(value="Generate", scale=2, variant="primary")
-            mixed_speech = gr.Audio(label="Mixed speech", scale=3)
+        mixed_speech = gr.Audio(label="Mixed speech", scale=3)
         generate_btn.click(
             partial(
                 exception_harness(

--- a/urvc
+++ b/urvc
@@ -30,7 +30,7 @@ main() {
         install)
             sudo apt install -y python3-dev build-essential unzip
             install_distro_specifics
-            install_cuda_125
+            install_cuda_128
             curl -LsSf https://astral.sh/uv/0.6.3/install.sh | sh
             uv run --extra "$URVC_ACCELERATOR" ./src/ultimate_rvc/core/main.py
             ;;
@@ -116,13 +116,13 @@ install_distro_specifics() {
     esac
 }
 
-install_cuda_125() {
-    echo "Installing CUDA 12.5"
+install_cuda_128() {
+    echo "Installing CUDA 12.8"
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
     sudo apt update
-    sudo apt -y install cuda-toolkit-12-5
+    sudo apt -y install cuda-toolkit-12-8
     rm -rf cuda-keyring_1.1-1_all.deb
-    echo "CUDA 12.5 has been installed successfully"
+    echo "CUDA 12.8 has been installed successfully"
 }
 
 check_dependencies() {


### PR DESCRIPTION
This PR promotes PyTorch to its latest stable versoin  (2.7.0) with CUDA 12.8 support. Let Blackwell be supported!